### PR TITLE
Make `SPC b b` and `SPC tab` more loyal to their Spacemacs counterparts

### DIFF
--- a/settings.json
+++ b/settings.json
@@ -35,7 +35,7 @@
             "after": [],
             "commands": [
                 {
-                    "command": "workbench.action.nextEditor",
+                    "command": "workbench.action.openNextRecentlyUsedEditorInGroup",
                     "args": []
                 }
             ]
@@ -88,7 +88,7 @@
             "after": [],
             "commands": [
                 {
-                    "command": "workbench.action.quickOpen",
+                    "command": "workbench.action.showAllEditors",
                     "args": []
                 }
             ]


### PR DESCRIPTION
A note on `SPC tab`:

Does the same command as `ctrl+tab`, but for some reason it doesn't close the viewlet that comes up automatically. However, once the list is opened it's very easy to `j`/`k` or `ctrl+n`/`ctrl+p` through it.