### PR TITLE
Add additional keybindings to open/resume search

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -99,6 +99,7 @@ Key bindings                     Description                                 Rem
 :kbd:`leader` :kbd:`'`           Toggle terminal                             Open terminal effectively
 :kbd:`leader` :kbd:`space`       Run command
 :kbd:`leader` :kbd:`tab`         Next editor
+:kbd:`leader` :kbd:`/`           Find in files
 :kbd:`leader` :kbd:`1`           Focus first editor group
 :kbd:`leader` :kbd:`2`           Focus second editor group
 :kbd:`leader` :kbd:`3`           Focus third editor group
@@ -125,6 +126,7 @@ Key bindings                     Description                                 Rem
 :kbd:`leader` :kbd:`q` :kbd:`f`  Close window
 :kbd:`leader` :kbd:`q` :kbd:`q`  Close window
 :kbd:`leader` :kbd:`q` :kbd:`r`  Reload window
+:kbd:`leader` :kbd:`r` :kbd:`s`  Find in files
 :kbd:`leader` :kbd:`s` :kbd:`e`  Rename symbol                               Works only on symbols
 :kbd:`leader` :kbd:`s` :kbd:`j`  Go to symbol in file
 :kbd:`leader` :kbd:`s` :kbd:`p`  Find in files
@@ -163,3 +165,4 @@ to this project:
 - `CodeFalling <https://github.com/CodeFalling>`_
 - `li-xinyang <https://github.com/li-xinyang>`_
 - `adrianstaniec <https://github.com/adrianstaniec>`_
+- `fabrik42 <https://github.com/fabrik42>`_

--- a/settings.json
+++ b/settings.json
@@ -43,6 +43,19 @@
         {
             "before": [
                 "<leader>",
+                "/"
+            ],
+            "after": [],
+            "commands": [
+                {
+                    "command": "workbench.action.findInFiles",
+                    "args": []
+                }
+            ]
+        },
+        {
+            "before": [
+                "<leader>",
                 "1"
             ],
             "after": [],
@@ -402,6 +415,20 @@
                 }
             ]
         },
+        {
+            "before": [
+                "<leader>",
+                "r",
+                "s"
+            ],
+            "after": [],
+            "commands": [
+                {
+                    "command": "workbench.action.findInFiles",
+                    "args": []
+                }
+            ]
+        },        
         {
             "before": [
                 "<leader>",


### PR DESCRIPTION
I added two keybindings, that are basically aliases to the existing `SPC s p` binding.
However, I use these much more in Spacemacs.

`SPC s p` and `SPC /` are equivalent in Spacemacs too.

`SPC r s` resumes the last search buffer in Spacemacs. 
In VS Code, the last search buffer is automatically resumed, so I just added it as an alias as well.