### PR TITLE
Reflect new VSCodeVim API changes

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -66,7 +66,7 @@ settings`` and then press :kbd:`Return`:
 
 - If you already have some VSCodeVim configurations, you will have to manually
   copy/paste the parts of `settings.json`_ into the corresponding
-  ``vim.otherModesKeyBindingsNonRecursive`` section of your ``settings.json``.
+  ``vim.normalModeKeyBindings`` section of your ``settings.json``.
 
 In any case it is recommended to keep the configurations you take from here
 grouped in your ``settings.json`` so you can easily update them by just

--- a/scripts/compile.js
+++ b/scripts/compile.js
@@ -5,7 +5,7 @@ const lodash = require("lodash");
 const bigSetting = path.join(__dirname, "..", "./settings.json");
 const smallSetting = path.join(__dirname,  "./settings.json");
 
-const keys = ["vim.otherModesKeyBindingsNonRecursive", "vim.insertModeKeyBindings"];
+const keys = ["vim.normalModeKeyBindings", "vim.insertModeKeyBindings"];
 
 function getBigKeyBinding(obj) {
     const result = [];

--- a/settings.json
+++ b/settings.json
@@ -1,6 +1,6 @@
 {
     "vim.leader": "<space>",
-    "vim.otherModesKeyBindingsNonRecursive": [
+    "vim.normalModeKeyBindings": [
         {
             "before": [
                 "<leader>",


### PR DESCRIPTION
This fixes the BC in VSCodeVim introduced in [v.0.13](https://github.com/VSCodeVim/Vim/compare/v0.13.0...master)

More info: see [docs](https://github.com/vscodevim/vim#viminsertmodekeybindingsvimnormalmodekeybindingsvimvisualmodekeybindings)