### PR TITLE
Fix Open recent (`leader` `f` `r`) command

### DIFF
--- a/settings.json
+++ b/settings.json
@@ -227,7 +227,7 @@
             "after": [],
             "commands": [
                 {
-                    "command": "workbench.action.openRecent",
+                    "command": "workbench.action.quickOpen",
                     "args": []
                 }
             ]


### PR DESCRIPTION
The open recent shortcut (<kbd>leader</kbd> <kbd>f</kbd> <kbd>r</kbd>) referenced the `openRecent` command, which is the same as <kbd>leader</kbd> <kbd>p</kbd> <kbd>p</kbd> (Open recent (show recent folders)). It should be `quickOpen` (what normally <kbd>Ctrl</kbd>+<kbd>p</kbd> is)