### PR TITLE
add comment-lines and format code to the visual mode

### DIFF
--- a/settings.json
+++ b/settings.json
@@ -14,6 +14,34 @@
                     "args": []
                 }
             ]
+        },
+        {
+            "before": [
+                "<leader>",
+                ";",
+                ";"
+            ],
+            "after": [],
+            "commands": [
+                {
+                    "command": "editor.action.commentLine",
+                    "args": []
+                }
+            ]
+        },
+        {
+            "before": [
+                "<leader>",
+                "j",
+                "="
+            ],
+            "after": [],
+            "commands": [
+                {
+                    "command": "editor.action.format",
+                    "args": []
+                }
+            ]
         }
     ],
     "vim.normalModeKeyBindings": [


### PR DESCRIPTION
Hi, I think vspacecode is awesome, I've been collecting quite a few extra shortcuts in my config (and I'm still adding more). I intend to slowly send them here as individual small PRs. To begin with, this one seems like a non-brainer: ability to format & comment code only for the selection (visual mode). I've basically just copy/pasted the normal mode commands to the visual mode section.