### PR TITLE
new shortcuts

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -132,6 +132,7 @@ Key bindings                     Description                                 Rem
 :kbd:`leader` :kbd:`f` :kbd:`T`  Select file in the explorer
 :kbd:`leader` :kbd:`f` :kbd:`y`  Copy current file path                      Doesn't show the path
 :kbd:`leader` :kbd:`g` :kbd:`b`  Git checkout
+:kbd:`leader` :kbd:`g` :kbd:`b`  Git blame                                   Requires the https://gitlens.amod.io/ VS code extension
 :kbd:`leader` :kbd:`g` :kbd:`c`  Git commit
 :kbd:`leader` :kbd:`g` :kbd:`d`  Git delete branch
 :kbd:`leader` :kbd:`g` :kbd:`f`  Git fetch

--- a/README.rst
+++ b/README.rst
@@ -171,6 +171,7 @@ Key bindings                     Description                                 Rem
 :kbd:`leader` :kbd:`w` :kbd:`-`  Split window below
 :kbd:`leader` :kbd:`w` :kbd:`/`  Split window to right
 :kbd:`leader` :kbd:`w` :kbd:`d`  Close editors in group
+:kbd:`leader` :kbd:`w` :kbd:`D`  Close other editors
 :kbd:`leader` :kbd:`w` :kbd:`h`  Previous editor group
 :kbd:`leader` :kbd:`w` :kbd:`H`  Move editor group to left
 :kbd:`leader` :kbd:`w` :kbd:`j`  Move window focus down

--- a/README.rst
+++ b/README.rst
@@ -129,6 +129,7 @@ Key bindings                     Description                                 Rem
 :kbd:`leader` :kbd:`f` :kbd:`r`  Open recent (show recent files)
 :kbd:`leader` :kbd:`f` :kbd:`s`  Save file
 :kbd:`leader` :kbd:`f` :kbd:`t`  Show explorer view
+:kbd:`leader` :kbd:`f` :kbd:`T`  Select file in the explorer
 :kbd:`leader` :kbd:`f` :kbd:`y`  Copy current file path                      Doesn't show the path
 :kbd:`leader` :kbd:`g` :kbd:`b`  Git checkout
 :kbd:`leader` :kbd:`g` :kbd:`c`  Git commit

--- a/README.rst
+++ b/README.rst
@@ -150,6 +150,7 @@ Key bindings                     Description                                 Rem
 :kbd:`leader` :kbd:`j` :kbd:`w`  Easymotion to word
 :kbd:`leader` :kbd:`l` :kbd:`d`  Close folder
 :kbd:`leader` :kbd:`p` :kbd:`f`  Quick open (allow to open any project file)
+:kbd:`leader` :kbd:`p` :kbd:`g`  Open file from editor group
 :kbd:`leader` :kbd:`p` :kbd:`l`  Open folder project
 :kbd:`leader` :kbd:`p` :kbd:`p`  Open recent (show recent folders)
 :kbd:`leader` :kbd:`p` :kbd:`t`  Show explorer view

--- a/settings.json
+++ b/settings.json
@@ -709,6 +709,20 @@
             "before": [
                 "<leader>",
                 "p",
+                "g"
+            ],
+            "after": [],
+            "commands": [
+                {
+                    "command": "workbench.action.showEditorsInActiveGroup",
+                    "args": []
+                }
+            ]
+        },
+        {
+            "before": [
+                "<leader>",
+                "p",
                 "l"
             ],
             "after": [],

--- a/settings.json
+++ b/settings.json
@@ -1001,6 +1001,20 @@
             "before": [
                 "<leader>",
                 "w",
+                "D"
+            ],
+            "after": [],
+            "commands": [
+                {
+                    "command": "workbench.action.closeOtherEditors",
+                    "args": []
+                }
+            ]
+        },
+        {
+            "before": [
+                "<leader>",
+                "w",
                 "h"
             ],
             "after": [],

--- a/settings.json
+++ b/settings.json
@@ -457,6 +457,19 @@
             "before": [
                 "<leader>",
                 "g",
+                "b"
+            ],
+            "commands": [
+                {
+                    "command": "gitlens.toggleFileBlame",
+                    "args": []
+                }
+            ]
+        },
+        {
+            "before": [
+                "<leader>",
+                "g",
                 "c"
             ],
             "after": [],

--- a/settings.json
+++ b/settings.json
@@ -415,6 +415,20 @@
             "before": [
                 "<leader>",
                 "f",
+                "T"
+            ],
+            "after": [],
+            "commands": [
+                {
+                    "command": "workbench.files.action.showActiveFileInExplorer",
+                    "args": []
+                }
+            ]
+        },
+        {
+            "before": [
+                "<leader>",
+                "f",
                 "y"
             ],
             "after": [],


### PR DESCRIPTION
as I announced in my previous PR, another shortcut now from my config... besides `leader f t` to show the explorer, this adds `leader f T` to select the current file in the explorer.

Let me know if you'd prefer one large PR (which would contain one commit per new shortcut) instead of multiple separate PRs. I thought the multiple PRs approach is better to discuss individual new shortcuts. I'm introducing the PRs now by submitting the most obvious shortcuts first. Later it gets a bit less clear which mnemonics we should use for individual shortcuts so I'm expecting you'll want to give more feedback on the shortcuts.