### PR TITLE
Added related projects section in README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -229,3 +229,8 @@ to this project:
 - `li-xinyang <https://github.com/li-xinyang>`_
 - `Raphael-Duchaine <https://github.com/Raphael-Duchaine>`_
 - `thanhvg <https://github.com/thanhvg>`_
+
+Related projects
+================
+
+- `IntelliSpace <https://github.com/MarcoIeni/intelli-space>`_ - Spacemacs' like key bindings for IntelliJ platform.


### PR DESCRIPTION
Hi, I was inspired by your project and I created [IntelliSpace](https://github.com/MarcoIeni/intelli-space), which brings the same concept of VSpaceCode to the IntelliJ platform.
I think that VSpaceCode users may be interested also in IntelliSpace and so I added a "related projects" section on the bottom of the README in which there is a link to my project. Of course you can add other projects like ours if you know some.
I hope that this is not too invasive.