### PR TITLE
Added spaceclipse to related projects

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -234,3 +234,4 @@ Related projects
 ================
 
 - `IntelliSpace <https://github.com/MarcoIeni/intelli-space>`_ - Spacemacs' like key bindings for IntelliJ platform.
+- `Spaceclipse <https://github.com/MarcoIeni/spaceclipse>`_ - Spacemacs' like key bindings for Eclipse.


### PR DESCRIPTION
I am the creator of [intelli-space](https://github.com/MarcoIeni/intelli-space), a project with the same aim of VSpaceCode but for the Intellij Platform.
Today I published [spaceclipse](https://github.com/MarcoIeni/spaceclipse), which does the same, but for the Eclipse IDE.
Since intelli-space is already present in the "Related projects" section, I added spaceclipse too :)