### PR TITLE
new vscode command more spacemacsey

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -174,7 +174,7 @@ Key bindings                     Description                                 Rem
 :kbd:`leader` :kbd:`w` :kbd:`k`  Move window focus up
 :kbd:`leader` :kbd:`w` :kbd:`l`  Next editor group
 :kbd:`leader` :kbd:`w` :kbd:`L`  Move editor group to right
-:kbd:`leader` :kbd:`w` :kbd:`m`  Maximize
+:kbd:`leader` :kbd:`w` :kbd:`m`  Toggle maximized panel (layout unpreserved)
 :kbd:`leader` :kbd:`w` :kbd:`v`  Split window
 :kbd:`leader` :kbd:`w` :kbd:`w`  Next editor group
 :kbd:`leader` :kbd:`w` :kbd:`W`  Previous editor group

--- a/README.rst
+++ b/README.rst
@@ -24,7 +24,7 @@ using other text editors. The goal of this project is to provide a configuration
 that maps Spacemacs key bindings to VSCode functionalities. This will allow
 users to continue using their muscle memory and and the mnemonics they know in
 VSCode.
-
+/cotr
 It is not possible to replicate the full Spacemacs experience within VScode, but
 it is at least possible to map some key bindings to functions offering the same
 features as Spacemacs does. For instance, :kbd:`SPC g s` in Spacemacs opens git
@@ -227,6 +227,7 @@ to this project:
 - `joefiorini <https://github.com/joefiorini>`_
 - `JuanCaicedo <https://github.com/JuanCaicedo>`_
 - `li-xinyang <https://github.com/li-xinyang>`_
+- `ossoso <https://github.com/ossoso>`_
 - `Raphael-Duchaine <https://github.com/Raphael-Duchaine>`_
 - `thanhvg <https://github.com/thanhvg>`_
 

--- a/settings.json
+++ b/settings.json
@@ -1049,7 +1049,7 @@
             "after": [],
             "commands": [
                 {
-                    "command": "workbench.action.maximizeEditor",
+                    "command": "workbench.action.toggleEditorWidths",
                     "args": []
                 }
             ]


### PR DESCRIPTION
A new command `Toggle Editor Group Sizes' was added in [1.38 ](https://code.visualstudio.com/updates/v1_38#_workbench) which resembles spacemacs behavior more. However, layout state prior to maximization is not stored and pane sizes are equalized on toggling back.
