### PR TITLE
`<SPC> w s` splits window below

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -191,6 +191,7 @@ Key bindings                      Description                                 Re
 :kbd:`leader` :kbd:`w` :kbd:`l`   Next editor group
 :kbd:`leader` :kbd:`w` :kbd:`L`   Move editor group to right
 :kbd:`leader` :kbd:`w` :kbd:`m`   Toggle maximized panel (layout unpreserved)
+:kbd:`leader` :kbd:`w` :kbd:`s`   Split window below
 :kbd:`leader` :kbd:`w` :kbd:`v`   Split window
 :kbd:`leader` :kbd:`w` :kbd:`w`   Next editor group
 :kbd:`leader` :kbd:`w` :kbd:`W`   Previous editor group

--- a/settings.json
+++ b/settings.json
@@ -1137,6 +1137,20 @@
             "before": [
                 "<leader>",
                 "w",
+                "s"
+            ],
+            "after": [],
+            "commands": [
+                {
+                    "command": "workbench.action.splitEditorDown",
+                    "args": []
+                }
+            ]
+        },
+        {
+            "before": [
+                "<leader>",
+                "w",
                 "v"
             ],
             "after": [],


### PR DESCRIPTION
Same as `<SPC> w -`