### PR TITLE
Add directional editor moving bindings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Add menu for magit ref `y` in normal mode
 - Add configuration commands for setting up both `settings.json` and `keybindings.json`
+- Add `<spc> b H/J/K/L` for directional editor moving
 
 ### Changed
 - Split the core menu logic to another extension (`vscode-which-key`) so this extension can be focused on Vim users

--- a/package.json
+++ b/package.json
@@ -133,6 +133,30 @@
 										"command": "workbench.action.closeActiveEditor"
 									},
 									{
+										"key": "H",
+										"name": "Move Editor into Left Group",
+										"type": "command",
+										"command": "workbench.action.moveEditorToLeftGroup"
+									},
+									{
+										"key": "J",
+										"name": "Move Editor into Below Group",
+										"type": "command",
+										"command": "workbench.action.moveEditorToBelowGroup"
+									},
+									{
+										"key": "K",
+										"name": "Move Editor into Above Group",
+										"type": "command",
+										"command": "workbench.action.moveEditorToAboveGroup"
+									},
+									{
+										"key": "L",
+										"name": "Move Editor into Right Group",
+										"type": "command",
+										"command": "workbench.action.moveEditorToRightGroup"
+									},
+									{
 										"key": "M",
 										"name": "Close other editors",
 										"type": "command",


### PR DESCRIPTION
This is a suggestion to add bindings similar to `<SPC w H/J/K/L>` for moving the active editor into other editor groups.