### PR TITLE
README: add badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,8 @@
 # VSpaceCode (Preview)
+[![Docs](https://img.shields.io/website?label=vspacecode.github.io&url=https%3A%2F%2Fvspacecode.github.io)](https://vspacecode.github.io)
+[![Version](https://vsmarketplacebadge.apphb.com/version/vspacecode.vspacecode.svg)](https://marketplace.visualstudio.com/items?itemName=vspacecode.vspacecode)
+[![Installs](https://vsmarketplacebadge.apphb.com/installs/vspacecode.vspacecode.svg)](https://marketplace.visualstudio.com/items?itemName=vspacecode.vspacecode)
+[![Ratings](https://vsmarketplacebadge.apphb.com/rating/vspacecode.vspacecode.svg)](https://marketplace.visualstudio.com/items?itemName=vspacecode.vspacecode)
 
 ![VSpaceCode Logo](resources/logo.png)
 


### PR DESCRIPTION
The main reason I am doing this is because I would like to change the website of this repo to vspacecode.github.io

Currently the link brings to the extension in the marketplace:

![image](https://user-images.githubusercontent.com/11428655/94375767-56142080-0116-11eb-9d5a-ef8807df5a1a.png)

By adding the link of the marketplace in the README, we could change it.
If you don't like some of the badges, please tell me, I am not so convinced about all of them.