### PR TITLE
simplify github templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -7,36 +7,48 @@ assignees: ''
 
 ---
 
-**Describe the bug**
-A clear and concise description of what the bug is.
+## Bug description
 
-**To Reproduce**
-Steps to reproduce the behavior:
+<!-- A clear and concise description of what the bug is. -->
 
+## To Reproduce
+
+<!--
+Steps to reproduce the behavior. Something like:
 1. Go to '...'
 2. Click on '....'
 3. Scroll down to '....'
 4. See error
+-->
 
-**Expected behavior**
-A clear and concise description of what you expected to happen.
+## Expected behavior
 
-**Screenshots**
-If applicable, add screenshots to help explain your problem.
+<!-- A clear and concise description of what you expected to happen. -->
 
-**Additional context**
-Add any other context about the problem here.
+## Screenshots
 
-**Settings**
+<!-- If applicable, add screenshots to help explain your problem. -->
+
+## Additional context
+
+<!-- Add any other context about the problem here. -->
+
+## Settings
+
+<!--
 Press `Ctrl+Shift+p` and run the action "Preferences: Open Settings (JSON)",
 or press `SPC f e D`  if key bindings work for you.
+-->
 
 ```
 Copy paste the content of your settings.json file here.
 ```
 
-**System information**
+## System information
+
+<!--
 - Press `Ctrl+Shift+p` and run the action "Help: Report Performance Issue", or
   press `SPC h I` if key bindings work for you.
 - Click "show" in "Include my system information" and "Include my enabled extensions"
 - Take a screenshot and copy paste it here.
+-->

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -7,14 +7,19 @@ assignees: ''
 
 ---
 
-**Is your feature request related to a problem? Please describe.**
-A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
+## Problem
 
-**Describe the solution you'd like**
-A clear and concise description of what you want to happen.
+<!--
+If your feature request is related to a problem, please describe it.
+Ex. I'm always frustrated when [...]
+-->
 
-**Describe alternatives you've considered**
-A clear and concise description of any alternative solutions or features you've considered.
+## Solution
 
-**Additional context**
-Add any other context or screenshots about the feature request here.
+<!-- Describe the solution you'd like. -->
+
+## Alternatives
+<!-- Describe any alternative solutions or features you've considered. -->
+
+## Additional context
+<!-- Add any other context or screenshots about the feature request here. -->

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,15 +1,11 @@
 ## Description
 
-Please explain the changes you made here.
+<!-- Please explain the changes you made here. -->
 
-## Checklist
-
-- [ ] I have read
-[CONTRIBUTING](https://github.com/VSpaceCode/VSpaceCode/blob/master/CONTRIBUTING.md)
-guidelines.
-
-#### [CHANGELOG](https://github.com/VSpaceCode/VSpaceCode/blob/master/CHANGELOG.md):
-
-- [ ] Updated
-- [ ] I will update it after this PR has been discussed
-- [ ] No need to update
+<!--
+Make sure that:
+- you have read the contributing guidelines:
+  https://github.com/VSpaceCode/VSpaceCode/blob/master/CONTRIBUTING.md
+- you have updated the changelog (if needed):
+  https://github.com/VSpaceCode/VSpaceCode/blob/master/CHANGELOG.md
+-->


### PR DESCRIPTION
I feel like the issue template may be a little bit intimidating at first.
Maybe if you don't see a wall of text in the preview it is better.

Additionally, with comments we make it clearer that all that text should me not included in your final message, too.