### PR TITLE
Markdown major mode

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,3 @@ dist
 node_modules
 .vscode-test/
 *.vsix
-
-snipsnap.code-snippets
-which-key-snippets.code-snippets

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,6 @@ dist
 node_modules
 .vscode-test/
 *.vsix
+
+snipsnap.code-snippets
+which-key-snippets.code-snippets

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 > See [Configuration](./README.md#Configuration) section in README
 
 ## [Unreleased]
+### Added
+- Add functions to Markdown "major mode" (`<spc> m`). Most functions require the [Markdown All in One](https://marketplace.visualstudio.com/items?itemName=yzhang.markdown-all-in-one) extension to be installed. These functions are:
+    + "Buffer commands..." functions (`<spc> m c`):
+        + `<spc> m c p` to open preview to the side
+        + `<spc> m c P` to open preview in current group
+        + `<spc> m c e` to export to HTML
+    + "Text..." functions (`<spc> m x`):
+        + `<spc> m x b` to toggle bold
+        + `<spc> m x ~` to toggle code block
+        + `` <spc> m x ` `` to toggle inline code
+        + `<spc> m x i` to toggle italic
+        + `<spc> m x l` to toggle list
+        + `<spc> m x m` to toggle math
+        + `<spc> m x s` to toggle strikethrough
+        + `<spc> m x ]` to increase heading level (transient)
+        + `<spc> m x [` to decrease heading leavel (transient)
+    + "Table of contents..." fuctions (`<spc> m t`):
+        + `<spc> m t c` to create table of contents
+        + `<spc> m t u` to update table of contents
+        + `<spc> m t n` to add section numbers
+        + `<spc> m t N` to remove section numbers
 
 ## [0.8.0] - 2020-09-21
 ### Changed

--- a/package.json
+++ b/package.json
@@ -1167,20 +1167,159 @@
 								"name": "Major...",
 								"type": "conditional",
 								"bindings": [
-									{
-										"key": "languageId:markdown",
-										"name": "Markdown",
-										"type": "bindings",
-										"bindings": [
-											{
-												"key": "p",
-												"name": "Open preview to the side",
-												"type": "command",
-												"command": "markdown.showPreviewToSide"
-											}
-										]
-									}
-								]
+                                    {
+                                        "key": "languageId:markdown",
+                                        "name": "Markdown",
+                                        "type": "bindings",
+                                        "bindings": [
+                                            {
+                                                "key": "t",
+                                                "name": "Table of Contents...",
+                                                "type": "bindings",
+                                                "bindings": [
+                                                    {
+                                                        "command": "markdown.extension.toc.create",
+                                                        "key": "c",
+                                                        "name": "Create ToC",
+                                                        "type": "command"
+                                                    },
+                                                    {
+                                                        "command": "markdown.extension.toc.update",
+                                                        "key": "u",
+                                                        "name": "Update ToC",
+                                                        "type": "command"
+                                                    },
+                                                    {
+                                                        "command": "markdown.extension.toc.addSecNumbers",
+                                                        "key": "n",
+                                                        "name": "Add section numbers",
+                                                        "type": "command"
+                                                    },
+                                                    {
+                                                        "command": "markdown.extension.toc.removeSecNumbers",
+                                                        "key": "N",
+                                                        "name": "Remove section numbers",
+                                                        "type": "command"
+                                                    }
+                                                ]
+                                            },
+                                            {
+                                                "key": "x",
+                                                "name": "Text...",
+                                                "type": "bindings",
+                                                "bindings": [
+                                                    {
+                                                        "command": "markdown.extension.editing.toggleBold",
+                                                        "key": "b",
+                                                        "name": "Toggle bold",
+                                                        "type": "command"
+                                                    },
+                                                    {
+                                                        "command": "markdown.extension.editing.toggleCodeBlock",
+                                                        "key": "~",
+                                                        "name": "Toggle code block",
+                                                        "type": "command"
+                                                    },
+                                                    {
+                                                        "command": "markdown.extension.editing.toggleCodeSpan",
+                                                        "key": "`",
+                                                        "name": "Toggle inline code",
+                                                        "type": "command"
+                                                    },
+                                                    {
+                                                        "command": "markdown.extension.editing.toggleItalic",
+                                                        "key": "i",
+                                                        "name": "Toggle italic",
+                                                        "type": "command"
+                                                    },
+                                                    {
+                                                        "command": "markdown.extension.editing.toggleList",
+                                                        "key": "l",
+                                                        "name": "Toggle list",
+                                                        "type": "command"
+                                                    },
+                                                    {
+                                                        "command": "markdown.extension.editing.toggleMath",
+                                                        "key": "m",
+                                                        "name": "Toggle math",
+                                                        "type": "command"
+                                                    },
+                                                    {
+                                                        "command": "markdown.extension.editing.toggleStrikethrough",
+                                                        "key": "s",
+                                                        "name": "Toggle strikethrough",
+                                                        "type": "command"
+                                                    },
+                                                    {
+                                                        "key": "]",
+                                                        "name": "Increase Heading level",
+                                                        "type": "transient",
+                                                        "command": "markdown.extension.editing.toggleHeadingUp",
+                                                        "bindings": [
+                                                            {
+                                                                "key": "]",
+                                                                "name": "Increase Heading level",
+                                                                "type": "command",
+                                                                "command": "markdown.extension.editing.toggleHeadingUp"
+                                                            },
+                                                            {
+                                                                "key": "[",
+                                                                "name": "Decrease Heading level",
+                                                                "type": "command",
+                                                                "command": "markdown.extension.editing.toggleHeadingDown"
+                                                            }
+                                                        ]
+                                                    },
+                                                    {
+                                                        "key": "[",
+                                                        "name": "Decrease Heading level",
+                                                        "type": "transient",
+                                                        "command": "markdown.extension.editing.toggleHeadingDown",
+                                                        "bindings": [
+                                                            {
+                                                                "key": "]",
+                                                                "name": "Increase Heading level",
+                                                                "type": "command",
+                                                                "command": "markdown.extension.editing.toggleHeadingUp"
+                                                            },
+                                                            {
+                                                                "key": "[",
+                                                                "name": "Decrease Heading level",
+                                                                "type": "command",
+                                                                "command": "markdown.extension.editing.toggleHeadingDown"
+                                                            }
+                                                        ]
+                                                    }
+                                                ]
+                                            },
+                                            {
+                                                "key": "c",
+                                                "name": "Buffer commands...",
+                                                "type": "bindings",
+                                                "bindings": [
+                                                    {
+                                                        "command": "markdown.showPreview",
+                                                        "key": "P",
+                                                        "name": "Open preview in current group",
+                                                        "type": "command"
+                                                    },
+                                                    {
+                                                        "key": "p",
+                                                        "name": "Open preview to the side",
+                                                        "type": "command",
+                                                        "command": "markdown.showPreviewToSide"
+                                                    },
+                                                    {
+                                                        "command": "markdown.extension.printToHtml",
+                                                        "key": "e",
+                                                        "name": "Export to HTML",
+                                                        "type": "command"
+                                                    }
+                                                ]
+                                            }
+                                        ]
+                                    }
+                                ]
 							},
 							{
 								"key": "p",

--- a/package.json
+++ b/package.json
@@ -1167,159 +1167,159 @@
 								"name": "Major...",
 								"type": "conditional",
 								"bindings": [
-                                    {
-                                        "key": "languageId:markdown",
-                                        "name": "Markdown",
-                                        "type": "bindings",
-                                        "bindings": [
-                                            {
-                                                "key": "t",
-                                                "name": "Table of Contents...",
-                                                "type": "bindings",
-                                                "bindings": [
-                                                    {
-                                                        "command": "markdown.extension.toc.create",
-                                                        "key": "c",
-                                                        "name": "Create Table of Contents",
-                                                        "type": "command"
-                                                    },
-                                                    {
-                                                        "command": "markdown.extension.toc.update",
-                                                        "key": "u",
-                                                        "name": "Update Table of Contents",
-                                                        "type": "command"
-                                                    },
-                                                    {
-                                                        "command": "markdown.extension.toc.addSecNumbers",
-                                                        "key": "n",
-                                                        "name": "Add section numbers",
-                                                        "type": "command"
-                                                    },
-                                                    {
-                                                        "command": "markdown.extension.toc.removeSecNumbers",
-                                                        "key": "N",
-                                                        "name": "Remove section numbers",
-                                                        "type": "command"
-                                                    }
-                                                ]
-                                            },
-                                            {
-                                                "key": "x",
-                                                "name": "Text...",
-                                                "type": "bindings",
-                                                "bindings": [
-                                                    {
-                                                        "command": "markdown.extension.editing.toggleBold",
-                                                        "key": "b",
-                                                        "name": "Toggle bold",
-                                                        "type": "command"
-                                                    },
-                                                    {
-                                                        "command": "markdown.extension.editing.toggleCodeBlock",
-                                                        "key": "~",
-                                                        "name": "Toggle code block",
-                                                        "type": "command"
-                                                    },
-                                                    {
-                                                        "command": "markdown.extension.editing.toggleCodeSpan",
-                                                        "key": "`",
-                                                        "name": "Toggle inline code",
-                                                        "type": "command"
-                                                    },
-                                                    {
-                                                        "command": "markdown.extension.editing.toggleItalic",
-                                                        "key": "i",
-                                                        "name": "Toggle italic",
-                                                        "type": "command"
-                                                    },
-                                                    {
-                                                        "command": "markdown.extension.editing.toggleList",
-                                                        "key": "l",
-                                                        "name": "Toggle list",
-                                                        "type": "command"
-                                                    },
-                                                    {
-                                                        "command": "markdown.extension.editing.toggleMath",
-                                                        "key": "m",
-                                                        "name": "Toggle math",
-                                                        "type": "command"
-                                                    },
-                                                    {
-                                                        "command": "markdown.extension.editing.toggleStrikethrough",
-                                                        "key": "s",
-                                                        "name": "Toggle strikethrough",
-                                                        "type": "command"
-                                                    },
-                                                    {
-                                                        "key": "]",
-                                                        "name": "Increase Heading level",
-                                                        "type": "transient",
-                                                        "command": "markdown.extension.editing.toggleHeadingUp",
-                                                        "bindings": [
-                                                            {
-                                                                "key": "]",
-                                                                "name": "Increase Heading level",
-                                                                "type": "command",
-                                                                "command": "markdown.extension.editing.toggleHeadingUp"
-                                                            },
-                                                            {
-                                                                "key": "[",
-                                                                "name": "Decrease Heading level",
-                                                                "type": "command",
-                                                                "command": "markdown.extension.editing.toggleHeadingDown"
-                                                            }
-                                                        ]
-                                                    },
-                                                    {
-                                                        "key": "[",
-                                                        "name": "Decrease Heading level",
-                                                        "type": "transient",
-                                                        "command": "markdown.extension.editing.toggleHeadingDown",
-                                                        "bindings": [
-                                                            {
-                                                                "key": "]",
-                                                                "name": "Increase Heading level",
-                                                                "type": "command",
-                                                                "command": "markdown.extension.editing.toggleHeadingUp"
-                                                            },
-                                                            {
-                                                                "key": "[",
-                                                                "name": "Decrease Heading level",
-                                                                "type": "command",
-                                                                "command": "markdown.extension.editing.toggleHeadingDown"
-                                                            }
-                                                        ]
-                                                    }
-                                                ]
-                                            },
-                                            {
-                                                "key": "c",
-                                                "name": "Buffer commands...",
-                                                "type": "bindings",
-                                                "bindings": [
-                                                    {
-                                                        "command": "markdown.showPreview",
-                                                        "key": "P",
-                                                        "name": "Open preview in current group",
-                                                        "type": "command"
-                                                    },
-                                                    {
-                                                        "key": "p",
-                                                        "name": "Open preview to the side",
-                                                        "type": "command",
-                                                        "command": "markdown.showPreviewToSide"
-                                                    },
-                                                    {
-                                                        "command": "markdown.extension.printToHtml",
-                                                        "key": "e",
-                                                        "name": "Export to HTML",
-                                                        "type": "command"
-                                                    }
-                                                ]
-                                            }
-                                        ]
-                                    }
-                                ]
+									{
+										"key": "languageId:markdown",
+										"name": "Markdown",
+										"type": "bindings",
+										"bindings": [
+											{
+												"key": "t",
+												"name": "Table of Contents...",
+												"type": "bindings",
+												"bindings": [
+													{
+														"command": "markdown.extension.toc.create",
+														"key": "c",
+														"name": "Create Table of Contents",
+														"type": "command"
+													},
+													{
+														"command": "markdown.extension.toc.update",
+														"key": "u",
+														"name": "Update Table of Contents",
+														"type": "command"
+													},
+													{
+														"command": "markdown.extension.toc.addSecNumbers",
+														"key": "n",
+														"name": "Add section numbers",
+														"type": "command"
+													},
+													{
+														"command": "markdown.extension.toc.removeSecNumbers",
+														"key": "N",
+														"name": "Remove section numbers",
+														"type": "command"
+													}
+												]
+											},
+											{
+												"key": "x",
+												"name": "Text...",
+												"type": "bindings",
+												"bindings": [
+													{
+														"command": "markdown.extension.editing.toggleBold",
+														"key": "b",
+														"name": "Toggle bold",
+														"type": "command"
+													},
+													{
+														"command": "markdown.extension.editing.toggleCodeBlock",
+														"key": "~",
+														"name": "Toggle code block",
+														"type": "command"
+													},
+													{
+														"command": "markdown.extension.editing.toggleCodeSpan",
+														"key": "`",
+														"name": "Toggle inline code",
+														"type": "command"
+													},
+													{
+														"command": "markdown.extension.editing.toggleItalic",
+														"key": "i",
+														"name": "Toggle italic",
+														"type": "command"
+													},
+													{
+														"command": "markdown.extension.editing.toggleList",
+														"key": "l",
+														"name": "Toggle list",
+														"type": "command"
+													},
+													{
+														"command": "markdown.extension.editing.toggleMath",
+														"key": "m",
+														"name": "Toggle math",
+														"type": "command"
+													},
+													{
+														"command": "markdown.extension.editing.toggleStrikethrough",
+														"key": "s",
+														"name": "Toggle strikethrough",
+														"type": "command"
+													},
+													{
+														"key": "]",
+														"name": "Increase Heading level",
+														"type": "transient",
+														"command": "markdown.extension.editing.toggleHeadingUp",
+														"bindings": [
+															{
+																"key": "]",
+																"name": "Increase Heading level",
+																"type": "command",
+																"command": "markdown.extension.editing.toggleHeadingUp"
+															},
+															{
+																"key": "[",
+																"name": "Decrease Heading level",
+																"type": "command",
+																"command": "markdown.extension.editing.toggleHeadingDown"
+															}
+														]
+													},
+													{
+														"key": "[",
+														"name": "Decrease Heading level",
+														"type": "transient",
+														"command": "markdown.extension.editing.toggleHeadingDown",
+														"bindings": [
+															{
+																"key": "]",
+																"name": "Increase Heading level",
+																"type": "command",
+																"command": "markdown.extension.editing.toggleHeadingUp"
+															},
+															{
+																"key": "[",
+																"name": "Decrease Heading level",
+																"type": "command",
+																"command": "markdown.extension.editing.toggleHeadingDown"
+															}
+														]
+													}
+												]
+											},
+											{
+												"key": "c",
+												"name": "Buffer commands...",
+												"type": "bindings",
+												"bindings": [
+													{
+														"command": "markdown.showPreview",
+														"key": "P",
+														"name": "Open preview in current group",
+														"type": "command"
+													},
+													{
+														"key": "p",
+														"name": "Open preview to the side",
+														"type": "command",
+														"command": "markdown.showPreviewToSide"
+													},
+													{
+														"command": "markdown.extension.printToHtml",
+														"key": "e",
+														"name": "Export to HTML",
+														"type": "command"
+													}
+												]
+											}
+										]
+									}
+								]
 							},
 							{
 								"key": "p",

--- a/package.json
+++ b/package.json
@@ -1180,13 +1180,13 @@
                                                     {
                                                         "command": "markdown.extension.toc.create",
                                                         "key": "c",
-                                                        "name": "Create ToC",
+                                                        "name": "Create Table of Contents",
                                                         "type": "command"
                                                     },
                                                     {
                                                         "command": "markdown.extension.toc.update",
                                                         "key": "u",
-                                                        "name": "Update ToC",
+                                                        "name": "Update Table of Contents",
                                                         "type": "command"
                                                     },
                                                     {


### PR DESCRIPTION
## Description

Closes #108.

Added menus and commands that made sense given what we have in [the **Markdown All in One** extension](https://marketplace.visualstudio.com/items?itemName=yzhang.markdown-all-in-one). Surprisingly enough, there aren't really _that many_ commands that the Markdown All in One extension provides, but I don't think we want to layer on a more extensions unless we have to.

One thing that came up when I was trying to put these together was that it'd be sweet if we could expand code snippets directly via vscode-which-key when when trying functionality that wasn't there, such as adding the `SPC m x k` mapping that's in the Spacemacs Markdown layer for example. Without a way to expand code snippets directly, I didn't think there was any appropriate way to add that. Potential feature request?

I referenced [the Markdown layer for Spacemacs](https://develop.spacemacs.org/layers/+lang/markdown/README.html) when trying to come up with where to put these mappings.

## Checklist

- [x] I have read [CONTRIBUTING](https://github.com/VSpaceCode/VSpaceCode/blob/master/CONTRIBUTING.md) guidelines.

#### [CHANGELOG](https://github.com/VSpaceCode/VSpaceCode/blob/master/CHANGELOG.md):

- [ ] Updated
- [x] I will update it after this PR has been discussed
- [ ] No need to update
