### PR TITLE
Disable which key in empty editor group during quick open

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - Fix the `<spc> j n` to split new line
+- ⌨️️ Fix which-key taking over when typing `<spc>` in the quick open dialog without an editor open
 
 ## [0.8.0] - 2020-09-21
 ### Changed

--- a/src/keybindings.jsonc
+++ b/src/keybindings.jsonc
@@ -3,7 +3,7 @@
     {
         "key": "space",
         "command": "vspacecode.space",
-        "when": "activeEditorGroupEmpty && focusedView == '' && !whichkeyActive"
+        "when": "activeEditorGroupEmpty && focusedView == '' && !whichkeyActive && !inQuickOpen"
     },
     // Keybindings required for edamagit
     // https://github.com/kahole/edamagit#vim-support-vscodevim


### PR DESCRIPTION
## Description

`focusedView` doesn't seem to populate when the quick open (command palette) dialog is in use.

As a result, the default keybindings allow which-key to take over if the user types a space in the command palette without an open editor.

## Checklist

- [x] I have read [CONTRIBUTING](https://github.com/VSpaceCode/VSpaceCode/blob/master/CONTRIBUTING.md) guidelines.

#### [CHANGELOG](https://github.com/VSpaceCode/VSpaceCode/blob/master/CHANGELOG.md):

- [x] Updated
- [ ] I will update it after this PR has been discussed
- [ ] No need to update
