### PR TITLE
Focus on the search result after `<spc> *`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -91,6 +91,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - Speed up vscode startup by deferred extension activation
 - Reorder the default keybindings in alphabetical order similar to spacemacs
+- Focus on the search result after `<spc> *`
 
 ### Fixed
 - Fix the issue where config default setting command normalized existing vim's keybindings (e.g. `<space>` to ` `) and can cause duplicate keybindings.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 > See [Configuration](https://vspacecode.github.io/docs/#manual-configuration-optional) section on our website
 
 ## [Unreleased]
+### Changed
+- Focus on the search result after `<spc> *`
 
 ## [0.8.3] - 2020-10-22
 ### Added
@@ -91,7 +93,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - Speed up vscode startup by deferred extension activation
 - Reorder the default keybindings in alphabetical order similar to spacemacs
-- Focus on the search result after `<spc> *`
 
 ### Fixed
 - Fix the issue where config default setting command normalized existing vim's keybindings (e.g. `<space>` to ` `) and can cause duplicate keybindings.

--- a/package.json
+++ b/package.json
@@ -176,7 +176,8 @@
 								"type": "commands",
 								"commands": [
 									"editor.action.addSelectionToNextFindMatch",
-									"workbench.action.findInFiles"
+									"workbench.action.findInFiles",
+									"search.action.focusSearchList"
 								]
 							},
 							{


### PR DESCRIPTION
This has been bugging me. I think `<spc> *` should focus on the search result, so user can navigate right the way with `j/k/l`