### PR TITLE
`<spc> b b` shows recent buffers first

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 - Focus on the search result after `<spc> *`
+- `<spc> b b` shows recent buffers first
 
 ## [0.8.3] - 2020-10-22
 ### Added

--- a/package.json
+++ b/package.json
@@ -281,7 +281,7 @@
 										"key": "b",
 										"name": "Show all buffers",
 										"type": "command",
-										"command": "workbench.action.showAllEditors"
+										"command": "workbench.action.showAllEditorsByMostRecentlyUsed"
 									},
 									{
 										"key": "d",


### PR DESCRIPTION
This reflects spacemacs behavior.
I don't find current `<spc> b b` ordering particularly useful.