### PR TITLE
Add project build test shortcuts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 > See [Configuration](https://vspacecode.github.io/docs/#manual-configuration-optional) section on our website
 
 ## [Unreleased]
+### Added
+- Add `<spc> p c` to run the default build task for the current project
+- Add `<spc> p T` to run the default test task for the current project
 
 ## [0.8.4] - 2020-11-23
 ### Added

--- a/package.json
+++ b/package.json
@@ -1205,6 +1205,12 @@
 								"type": "bindings",
 								"bindings": [
 									{
+										"key": "c",
+										"name": "Compile project",
+										"type": "command",
+										"command": "workbench.action.tasks.build"
+									},
+									{
 										"key": "f",
 										"name": "Find file in project...",
 										"type": "command",
@@ -1233,6 +1239,12 @@
 										"name": "Replace in files...",
 										"type": "command",
 										"command": "workbench.action.replaceInFiles"
+									},
+									{
+										"key": "T",
+										"name": "Test project",
+										"type": "command",
+										"command": "workbench.action.tasks.test"
 									}
 								]
 							},


### PR DESCRIPTION
As discussed in #141, this pull request adds bindings to run the default build and default test tasks for a project, mapped to `<spc> pc` and `<spc> pT` respectively.

A Changelog update is also included.
