### PR TITLE
Add `<spc> T n` and `<spc> S n`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 > See [Configuration](https://vspacecode.github.io/docs/#manual-configuration-optional) section on our website
 
 ## [Unreleased]
+### Added
+- Add `<spc> T n` to toggle notification center
+- Add `<spc> S n` to show notification center
 
 ## [0.8.5] - 2020-11-22
 ### Added

--- a/package.json
+++ b/package.json
@@ -2721,6 +2721,12 @@
 										"command": "workbench.view.scm"
 									},
 									{
+										"key": "n",
+										"name": "Show notification",
+										"type": "command",
+										"command": "notifications.showList"
+									},
+									{
 										"key": "o",
 										"name": "Show output",
 										"type": "command",
@@ -2792,6 +2798,12 @@
 										"name": "Toggle maximized panel",
 										"type": "command",
 										"command": "workbench.action.toggleMaximizedPanel"
+									},
+									{
+										"key": "n",
+										"name": "Toggle notification",
+										"type": "command",
+										"command": "notifications.toggleList"
 									},
 									{
 										"key": "s",


### PR DESCRIPTION
We don't have any key bindings to enter into the notifications center. This PR add keys to toggle and show the notification center.

Some built-in behavior of the notification center:
- `j/k` and arrow keys can already be use directly with list (the `j/k` control is probably coming from vim's built-in bindings on list)
- `<esc>` can be used to close the view
- `cmd+backspace` can use to dismiss a notification on mac
