### PR TITLE
Add next & previous change commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Add `<spc> b h/j/k/l` for directional editor moving
 - Add `<spc> S n` to show notification center
+- Add `<spc> j c` for previous change, `<spc> j C` for next change
 
 ## [0.8.5] - 2020-12-11
 ### Added

--- a/package.json
+++ b/package.json
@@ -1162,12 +1162,6 @@
 										"command": "workbench.action.editor.previousChange"
 									},
 									{
-										"key": "C",
-										"name": "Jump to next change",
-										"type": "command",
-										"command": "workbench.action.editor.nextChange"
-									},
-									{
 										"key": "i",
 										"name": "Jump to symbol in buffer",
 										"type": "command",
@@ -1230,6 +1224,12 @@
 												"w"
 											]
 										}
+									},
+									{
+										"key": "C",
+										"name": "Jump to next change",
+										"type": "command",
+										"command": "workbench.action.editor.nextChange"
 									},
 									{
 										"key": "I",

--- a/package.json
+++ b/package.json
@@ -1156,16 +1156,16 @@
 										"command": "editor.action.format"
 									},
 									{
-										"key": "C",
-										"name": "Jump to next change",
-										"type": "command",
-										"command": "workbench.action.editor.nextChange"
-									},
-									{
 										"key": "c",
 										"name": "Jump to previous change",
 										"type": "command",
 										"command": "workbench.action.editor.previousChange"
+									},
+									{
+										"key": "C",
+										"name": "Jump to next change",
+										"type": "command",
+										"command": "workbench.action.editor.nextChange"
 									},
 									{
 										"key": "i",

--- a/package.json
+++ b/package.json
@@ -1156,6 +1156,18 @@
 										"command": "editor.action.format"
 									},
 									{
+										"key": "C",
+										"name": "Jump to next change",
+										"type": "command",
+										"command": "workbench.action.editor.nextChange"
+									},
+									{
+										"key": "c",
+										"name": "Jump to previous change",
+										"type": "command",
+										"command": "workbench.action.editor.previousChange"
+									},
+									{
 										"key": "i",
 										"name": "Jump to symbol in buffer",
 										"type": "command",


### PR DESCRIPTION
<!-- Please explain the changes you made -->

<!--
Please, make sure:
- you have read the contributing guidelines:
  https://github.com/VSpaceCode/VSpaceCode/blob/master/CONTRIBUTING.md
- you have updated the changelog (if needed):
  https://github.com/VSpaceCode/VSpaceCode/blob/master/CHANGELOG.md
-->

Closes https://github.com/VSpaceCode/VSpaceCode/issues/150

Note that the `c` / `C` is the opposite orientation of `n` / `N`. Not sure how we balance consistency with spacemacs and consistency across commands.