### PR TITLE
Trigger vspacecode when sidebar is in focus

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ### Added
+- ⌨ Trigger vspacecode when sidebar is in focus
 - Add `<spc> b h/j/k/l` for directional editor moving
 - Add `<spc> S n` to show notification center
 - Add `<spc> j c` for previous change, `<spc> j C` for next change

--- a/src/configuration/keybindings.jsonc
+++ b/src/configuration/keybindings.jsonc
@@ -5,6 +5,12 @@
         "command": "vspacecode.space",
         "when": "activeEditorGroupEmpty && focusedView == '' && !whichkeyActive && !inputFocus"
     },
+    // Trigger vspacecode when sidebar is in focus
+    {
+        "key": "space",
+        "command": "vspacecode.space",
+        "when": "sideBarFocus && !inputFocus && !whichkeyActive"
+    },
     // Keybindings required for edamagit
     // https://github.com/kahole/edamagit#vim-support-vscodevim
     // Cannot be added to package.json because keybinding replacements


### PR DESCRIPTION
Related: #85, #163

This PR add keybinding to trigger vspacecode when sidebar is in focus. I've been using it for a while, and it seems to be okay for the most part. Also I don't have extension that uses custom webview on the sidebar to test that case.