### PR TITLE
Add the 'Go to' bindings for Python major mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 - Change the order of the spacemacs to be more aligned with spacemacs
+- Add functions to Python "major mode" (`<spc> m`). Most functions require the [Python](https://marketplace.visualstudio.com/items?itemName=ms-python.python) extension to be installed.
+    + "Go to commands..." menu (`<spc> m g`):
+        + `<spc> m g d` to go to definition
+        + `<spc> m g e` to go to errors/problems
+        + `<spc> m g g` to go to definition
+        + `<spc> m g i` to find symbol in file
+        + `<spc> m g r` to peek references
+        + `<spc> m g D` to peek definition
+        + `<spc> m g I` to find symbols in project
+        + `<spc> m g R` to find all references
 
 ## [0.9.0] - 2021-01-25
 ### Added

--- a/package.json
+++ b/package.json
@@ -3070,6 +3070,61 @@
 												]
 											},
 											{
+												"key": "g",
+												"name": "Go to",
+												"type": "bindings",
+												"bindings": [
+													{
+														"key": "d",
+														"name": "Go to definition",
+														"type": "command",
+														"command": "editor.action.revealDefinition"
+													},
+													{
+														"key": "e",
+														"name": "Go to errors/problems",
+														"type": "command",
+														"command": "workbench.action.problems.focus"
+													},
+													{
+														"key": "g",
+														"name": "Go to definition",
+														"type": "command",
+														"command": "editor.action.revealDefinition"
+													},
+													{
+														"key": "i",
+														"name": "Find symbol in file",
+														"type": "command",
+														"command": "workbench.action.gotoSymbol"
+													},
+													{
+														"key": "r",
+														"name": "Peek references",
+														"type": "command",
+														"command": "editor.action.referenceSearch.trigger"
+													},
+													{
+														"key": "D",
+														"name": "Peek definition",
+														"type": "command",
+														"command": "editor.action.peekDefinition"
+													},
+													{
+														"key": "I",
+														"name": "Find symbol in project",
+														"type": "command",
+														"command": "workbench.action.showAllSymbols"
+													},
+													{
+														"key": "R",
+														"name": "Find all references",
+														"type": "command",
+														"command": "references-view.findReferences"
+													}
+												]
+											},
+											{
 												"key": "r",
 												"name": "+Refactor",
 												"type": "bindings",


### PR DESCRIPTION
Add the `g` prefix to Python major mode with bindings for "Go to".

These are not necessarily the full list of bindings from Spacemacs, but
are similar to the bindings VSpaceCode has for Ruby for now and should
cover many of the common use cases.