### PR TITLE
Add `b` backend to Python major mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add `b` backend to Python major mode
+
 ### Fixed
 
 - Fix the missing `+` prefix for "Go to" key in python major mode

--- a/package.json
+++ b/package.json
@@ -3361,6 +3361,25 @@
 												]
 											},
 											{
+												"key": "b",
+												"name": "+Backend",
+												"type": "bindings",
+												"bindings": [
+													{
+														"key": "o",
+														"name": "Show LSP output",
+														"type": "command",
+														"command": "python.viewLanguageServerOutput"
+													},
+													{
+														"key": "r",
+														"name": "Restart LSP",
+														"type": "command",
+														"command": "python.analysis.restartLanguageServer"
+													}
+												]
+											},
+											{
 												"key": "c",
 												"name": "+Execute",
 												"type": "bindings",


### PR DESCRIPTION
Add `SPC m b r` to restart LSP, and `SPC m b o` to show the output of LSP for Python Major mode
