### PR TITLE
fix: change when express of vspacecode.space

### DIFF
--- a/src/configuration/keybindings.jsonc
+++ b/src/configuration/keybindings.jsonc
@@ -9,7 +9,7 @@
     {
         "key": "space",
         "command": "vspacecode.space",
-        "when": "sideBarFocus && !inputFocus && !whichkeyActive"
+        "when": "!inputFocus && !whichkeyActive"
     },
     // Keybindings required for edamagit
     // https://github.com/kahole/edamagit#vim-support-vscodevim


### PR DESCRIPTION
I can't trigger Which Key (pressing space) on Welcome Screen and others screens that are not editors.

To fix this issue I edited the when expression of VSpacecode: Show VSpaceCode Menu

from

sideBarFocus && !inputFocus && !whichkeyActive

to

!inputFocus && !whichkeyActive


Related to https://github.com/VSpaceCode/VSpaceCode/issues/197

<!-- Please explain the changes you made -->

<!--
Please, make sure:
- you have read the contributing guidelines:
  https://github.com/VSpaceCode/VSpaceCode/blob/master/CONTRIBUTING.md
- you have updated the changelog (if needed):
  https://github.com/VSpaceCode/VSpaceCode/blob/master/CHANGELOG.md
-->
