### PR TITLE
Remove duplicate show terminal binding

### DIFF
--- a/package.json
+++ b/package.json
@@ -271,12 +271,6 @@
 								"command": "whichkey.searchBindings"
 							},
 							{
-								"key": "?",
-								"name": "Show terminal",
-								"type": "command",
-								"command": "workbench.action.terminal.focus"
-							},
-							{
 								"key": "v",
 								"name": "Smart select/expand region",
 								"type": "transient",


### PR DESCRIPTION
Seems to be added by accident in a52b6f5ed562dd3cb0f15f756061af86dca5b694 and then shadowed in 1d1c3990a6e5170ba90997e3d2a79c3a5214c648.