### PR TITLE
Add more refactoring bindings to Python mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,8 +15,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- New refactoring bindings in Python major mode: `r v` to extract variable and
-  `r m` to extract method.
+- Add additional refactoring bindings in Python major mode
+  + `r v` to extract variable
+  + `r m` to extract method
 
 ## [0.10.0] - 2021-06-27
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- New refactoring bindings in Python major mode: `r v` to extract variable and
+  `r m` to extract method.
+
 ## [0.10.0] - 2021-06-27
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -3931,6 +3931,20 @@
 												"type": "bindings",
 												"bindings": [
 													{
+														"key": "m",
+														"name": "Extract method",
+														"icon": "symbol-method",
+														"type": "command",
+														"command": "python.refactorExtractMethod"
+													},
+													{
+														"key": "v",
+														"name": "Extract variable",
+														"icon": "variable",
+														"type": "command",
+														"command": "python.refactorExtractVariable"
+													},
+													{
 														"key": "I",
 														"name": "Sort imports",
 														"icon": "selection",


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/625793/123671920-17df9500-d83f-11eb-8d99-ef05f4f0f3e5.png)

Seems like they've been around in the Python extension for a long time: https://github.com/Microsoft/vscode-python/commit/280f77eb36c82e170e4d31d172f93158f60b0173