### PR TITLE
Add settings to fix vim navigation key in peek

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add default setting config to fix vim navigation keys in peek view for vscode 1.58
+
 ## [0.10.1] - 2021-07-04
 
 ### Added

--- a/src/configuration/settings.jsonc
+++ b/src/configuration/settings.jsonc
@@ -1,4 +1,9 @@
 {
+    // Disable Automatic Keyboard Navigation so
+    // keys like h, j, k, l work under a peek tree view
+    // with keybinding contributed from VsCode Vim.
+    // This setting is needed since vscode 1.58
+    "workbench.list.automaticKeyboardNavigation": false,
     // Vim easymotion is required for Jump menu - <SPC> j
     "vim.easymotion": true,
     // Use system clipboard for vim


### PR DESCRIPTION
Disable Automatic Keyboard Navigation in our default setting config so keys like h, j, k, l work under a peek tree view with keybinding contributed from VsCode Vim (https://github.com/VSCodeVim/Vim/blob/v1.21.5/package.json#L148-L172).

the vim navigation key started to fail in peek view in vscode 1.58, and I am not sure if they change the setting's default value, if there's some regression or bugfix that caused this behavior. I will open an issue in vscode when I have time. Meanwhile, I am opening this PR and the intent is to at least let people know of this issue.

Will merge this once we get a clarification if this is an intended behavior from vscode.
