### PR TITLE
Update bindings for Go lang

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Add major mode for Dart/Flutter
 
+### Changed
+
+- Update some bindings in the go to menu for Go lang
+  - Add `g c` to peak call hierarchy
+  - Add `g C` to show call hierarchy in the side bar
+  - Change `g i` to go to implementations from go to symbol which exists in `<spc> j i`
+  - Change `g I` to find all implementations from show all symbols which exists in `<spc> j I`
+  - Remove `g m` as the command is not valid
+  - Move `t t` toggle test  to `t T`
+  - Move `t f` test function at cursor to `t t`
+  - Move `t F` test file to `t f`
+
 ## [0.10.1] - 2021-07-04
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -3490,6 +3490,13 @@
 												"type": "bindings",
 												"bindings": [
 													{
+														"key": "c",
+														"name": "Peak call hierarchy",
+														"icon": "type-hierarchy",
+														"type": "command",
+														"command": "editor.showCallHierarchy"
+													},
+													{
 														"key": "d",
 														"name": "Go to definition",
 														"icon": "symbol-function",
@@ -3512,17 +3519,10 @@
 													},
 													{
 														"key": "i",
-														"name": "Find symbol in file",
-														"icon": "file",
+														"name": "Go to implementations",
+														"icon": "symbol-module",
 														"type": "command",
-														"command": "workbench.action.gotoSymbol"
-													},
-													{
-														"key": "m",
-														"name": "Go to method in file",
-														"icon": "symbol-method",
-														"type": "command",
-														"command": "workbench.action.gotoMethod"
+														"command": "editor.action.goToImplementation"
 													},
 													{
 														"key": "r",
@@ -3539,6 +3539,13 @@
 														"command": "editor.action.goToTypeDefinition"
 													},
 													{
+														"key": "C",
+														"name": "Show call hierarchy",
+														"icon": "type-hierarchy",
+														"type": "command",
+														"command": "references-view.showCallHierarchy"
+													},
+													{
 														"key": "D",
 														"name": "Peek definition",
 														"icon": "symbol-function",
@@ -3547,10 +3554,10 @@
 													},
 													{
 														"key": "I",
-														"name": "Find symbol in project",
-														"icon": "project",
+														"name": "Find all implementation",
+														"icon": "symbol-module",
 														"type": "command",
-														"command": "workbench.action.showAllSymbols"
+														"command": "references-view.findImplementations"
 													},
 													{
 														"key": "R",
@@ -3665,10 +3672,10 @@
 													},
 													{
 														"key": "f",
-														"name": "Test function at cursor",
-														"icon": "whole-word",
+														"name": "Test file",
+														"icon": "file",
 														"type": "command",
-														"command": "go.test.cursor"
+														"command": "go.test.file"
 													},
 													{
 														"key": "l",
@@ -3692,18 +3699,18 @@
 														"command": "go.subtest.cursor"
 													},
 													{
+														"key": "t",
+														"name": "Test function at cursor",
+														"icon": "whole-word",
+														"type": "command",
+														"command": "go.test.cursor"
+													},
+													{
 														"key": "w",
 														"name": "Test packages in workspace",
 														"icon": "project",
 														"type": "command",
 														"command": "go.test.workspace"
-													},
-													{
-														"key": "F",
-														"name": "Test file",
-														"icon": "file",
-														"type": "command",
-														"command": "go.test.file"
 													},
 													{
 														"key": "P",
@@ -3771,7 +3778,7 @@
 														]
 													},
 													{
-														"key": "t",
+														"key": "T",
 														"name": "+Toggle",
 														"icon": "settings",
 														"type": "bindings",


### PR DESCRIPTION
This commits
- Add `g c` to peak call hierarchy
- Add `g C` to show call hierarchy in the side bar
- Change `g i` to go to implementations from go to symbol which exists in `<spc> j i`
- Change `g I` to find all implementations from show all symbols which exists in `<spc> j I`
- Remove `g m` as the command is not valid
- Move `t t` toggle test  to `t T`
- Move `t f` test function at cursor to `t t`
- Move `t F` test file to `t f`

Reasons:
- Hierarchy is a feature go lang LSP implemented. Think it would be nice to have have it in the keybindings. (We probably also should standardize `g c`/`g C` for language that implemented call hierarchy.)
- The go to menu was missing go to implementations and it's very frustrating to deal with interfere in go lang.
- The key `g m` is not valid, and yield error "Error: command 'workbench.action.gotoMethod' not found"
- The change in test menu is to make it more ergonomic and closer to spacemacs (See https://develop.spacemacs.org/layers/+lang/go/README.html#key-bindings)
  - `t t` should test function under cursor hence move existing `t t` toggle test menu to `t T`
  - Since `t f` test function is moved to `t t`, `t F` test file is moved to `t f`