### PR TITLE
Update binding for test explorer for unittest

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 > See [Configuration](https://vspacecode.github.io/docs/#manual-configuration-optional) section on our website
 
 ## [Unreleased]
-
+- Add some bindings for test explorer(hbenl.vscode-test-explorer)
+  - Add `u u` to run unittest under cursor
+  - Add `u t` to open test explorer
+  - Add `u r` to redebug last unittest
+  - Add `u d` to debug unittest under cursor
+  - Add `u f` to debug failed test
+  - Add `u l` to show unittest failed log
+  - Add `u b` to run unittest in current file
+  - Add `u c` to cancel running unittest
 ## [0.10.2] - 2021-08-22
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -5135,6 +5135,70 @@
 								]
 							},
 							{
+								"key": "u",
+								"name": "+Unittest...",
+								"icon": "tools",
+								"type": "bindings",
+								"bindings": [
+									{
+										"key": "u",
+										"name": "Run current test",
+										"icon": "run",
+										"type": "command",
+										"command": "testing.runAtCursor"
+									},
+									{
+										"key": "t",
+										"name": "Open test explorer",
+										"icon": "list-selection",
+										"type": "command",
+										"command": "workbench.view.testing.focus"
+									},
+									{
+										"key": "r",
+										"name": "Redebug last test",
+										"icon": "debug-restart",
+										"type": "command",
+										"command": "testing.debugLastRun"
+									},
+									{
+										"key": "d",
+										"name": "Debug current test",
+										"icon": "debug-start",
+										"type": "command",
+										"command": "test-explorer.debug-test-at-cursor"
+									},
+									{
+										"key": "f",
+										"name": "Debug fail tests",
+										"icon": "error",
+										"type": "command",
+										"command": "testing.debugFailTests"
+									},
+									{
+										"key": "l",
+										"name": "Show test log",
+										"icon": "list-flat",
+										"type": "command",
+										"command": "testing.debugAtCursor"
+									},
+									{
+										"key": "b",
+										"name": "Run current test file",
+										"icon": "file",
+										"type": "command",
+										"command": "test-explorer.run-file"
+									},
+									{
+										"key": "c",
+										"name": "Cancel running tests",
+										"icon": "close",
+										"type": "command",
+										"command": "testing.cancelRun"
+									}
+								]
+							},
+							{
 								"key": "w",
 								"name": "+Window",
 								"icon": "split-horizontal",


### PR DESCRIPTION
This commits
- Add `t t` to open test explorer
- Add `t u` to run unittest under cursor
- Add `t d` to debug unittest under cursor
- Add `t r` to redebug last unittest

<!-- Please explain the changes you made -->

<!--
Please, make sure:
- you have read the contributing guidelines:
  https://github.com/VSpaceCode/VSpaceCode/blob/master/CONTRIBUTING.md
- you have updated the changelog (if needed):
  https://github.com/VSpaceCode/VSpaceCode/blob/master/CHANGELOG.md
- `npm run sort-bindings` is run to ensure the bindings are sorted
  (if you are contributing updates to bindings)
-->
