### PR TITLE
add more key bindings for Rust major mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     - `<SPC> m a s` to execute source action
     - `<SPC> m a r` to show "+Refactor" menu
       - `<SPC> m a r .` to execute refactor action
-      - `<SPC> m a r r` to renable symbol
+      - `<SPC> m a r r` to rename symbol
   - "+Goto" menu (`<SPC> m g`):
     - `<SPC> m g d` to find definition
     - `<SPC> m g h` to go to call hierarchy

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,30 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add additional bindings in Rust major mode
+  - "+Action" menu (`<SPC> m a`):
+    - `<SPC> m a a` to execute code action
+    - `<SPC> m a f` to execute fix action
+    - `<SPC> m a s` to execute source action
+    - `<SPC> m a r` to show "+Refactor" menu
+      - `<SPC> m a r .` to execute refactor action
+      - `<SPC> m a r r` to renable symbol
+  - "+Goto" menu (`<SPC> m g`):
+    - `<SPC> m g d` to find definition
+    - `<SPC> m g h` to go to call hierarchy
+    - `<SPC> m g i` to find implementations
+    - `<SPC> m g r` to find references
+    - `<SPC> m g s` to find symbol in file
+    - `<SPC> m g t` to go to type definition
+    - `<SPC> m g S` to find symbol in project
+  - "+Peek" menu (`SPC m G`):
+    - `<SPC> m G d` to peek definition
+    - `<SPC> m G h` to show call hierarchy
+    - `<SPC> m G i` to peek implementation
+    - `<SPC> m G r` to peek references
+
 ## [0.10.2] - 2021-08-22
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -4795,6 +4795,57 @@
 												]
 											},
 											{
+												"key": "a",
+												"name": "+Actions",
+												"icon": "zap",
+												"type": "bindings",
+												"bindings": [
+													{
+														"key": "a",
+														"name": "Execute code action",
+														"icon": "lightbulb",
+														"type": "command",
+														"command": "editor.action.codeAction"
+													},
+													{
+														"key": "f",
+														"name": "Execute fix action",
+														"icon": "lightbulb-autofix",
+														"type": "command",
+														"command": "editor.action.quickFix"
+													},
+													{
+														"key": "s",
+														"name": "Execute source action",
+														"icon": "lightbulb",
+														"type": "command",
+														"command": "editor.action.sourceAction"
+													},
+													{
+														"key": "r",
+														"name": "+Refactor",
+														"icon": "edit",
+														"type": "bindings",
+														"bindings": [
+															{
+																"key": ".",
+																"name": "Execute refactor action",
+																"icon": "lightbulb-autofix",
+																"type": "command",
+																"command": "editor.action.refactor"
+															},
+															{
+																"key": "r",
+																"name": "Rename symbol",
+																"icon": "symbol-keyword",
+																"type": "command",
+																"command": "editor.action.rename"
+															}
+														]
+													}
+												]
+											},
+											{
 												"key": "b",
 												"name": "+Backend",
 												"icon": "circuit-board",
@@ -4827,6 +4878,99 @@
 														"icon": "refresh",
 														"type": "command",
 														"command": "rust-analyzer.reloadWorkspace"
+													}
+												]
+											},
+											{
+												"key": "g",
+												"name": "+Goto",
+												"icon": "go-to-file",
+												"type": "bindings",
+												"bindings": [
+													{
+														"key": "d",
+														"name": "Find defenition",
+														"icon": "symbol-function",
+														"type": "command",
+														"command": "editor.action.revealDefinition"
+													},
+													{
+														"key": "h",
+														"name": "Go to call hierachy",
+														"icon": "type-hierarchy",
+														"type": "command",
+														"command": "references-view.showCallHierarchy"
+													},
+													{
+														"key": "i",
+														"name": "Find implementations",
+														"icon": "symbol-module",
+														"type": "command",
+														"command": "editor.action.goToImplementation"
+													},
+													{
+														"key": "r",
+														"name": "Find references",
+														"icon": "symbol-reference",
+														"type": "command",
+														"command": "references-view.findReferences"
+													},
+													{
+														"key": "s",
+														"name": "Find symbol in file",
+														"icon": "file",
+														"type": "command",
+														"command": "workbench.action.gotoSymbol"
+													},
+													{
+														"key": "t",
+														"name": "Go to type definition",
+														"icon": "symbol-struct",
+														"type": "command",
+														"command": "editor.action.goToTypeDefinition"
+													},
+													{
+														"key": "S",
+														"name": "Find symbol in project",
+														"icon": "project",
+														"type": "command",
+														"command": "workbench.action.showAllSymbols"
+													}
+												]
+											},
+											{
+												"key": "G",
+												"name": "+Peek",
+												"icon": "eye",
+												"type": "bindings",
+												"bindings": [
+													{
+														"key": "d",
+														"name": "Peek definition",
+														"icon": "symbol-function",
+														"type": "command",
+														"command": "editor.action.peekDefinition"
+													},
+													{
+														"key": "h",
+														"name": "show call hierarchy",
+														"icon": "type-hierarchy",
+														"type": "command",
+														"command": "editor.showCallHierarchy"
+													},
+													{
+														"key": "i",
+														"name": "Peek implementation",
+														"icon": "symbol-module",
+														"type": "command",
+														"command": "editor.action.peekImplementation"
+													},
+													{
+														"key": "r",
+														"name": "Peek references",
+														"icon": "symbol-reference",
+														"type": "command",
+														"command": "editor.action.referenceSearch.trigger"
 													}
 												]
 											}

--- a/package.json
+++ b/package.json
@@ -4896,7 +4896,7 @@
 													},
 													{
 														"key": "h",
-														"name": "Go to call hierachy",
+														"name": "Go to call hierarchy",
 														"icon": "type-hierarchy",
 														"type": "command",
 														"command": "references-view.showCallHierarchy"

--- a/package.json
+++ b/package.json
@@ -4953,7 +4953,7 @@
 													},
 													{
 														"key": "h",
-														"name": "show call hierarchy",
+														"name": "Show call hierarchy",
 														"icon": "type-hierarchy",
 														"type": "command",
 														"command": "editor.showCallHierarchy"


### PR DESCRIPTION
<!-- Please explain the changes you made -->
I've added key bindings for `+Actions`, `+Goto`, and `+Peek`, referring
to spacemacs LSP layer [docs](https://develop.spacemacs.org/layers/+tools/lsp/README.html) and VSpaceCode [conventions](https://vspacecode.github.io/docs/conventions/).

I have not added bindings starting with `SPC m c`. To implement these bindings of [Rust layer](https://develop.spacemacs.org/layers/+lang/rust/README.html), I think we will need to implement a new extension using `cargo`.
<!--
Please, make sure:
- you have read the contributing guidelines:
  https://github.com/VSpaceCode/VSpaceCode/blob/master/CONTRIBUTING.md
- you have updated the changelog (if needed):
  https://github.com/VSpaceCode/VSpaceCode/blob/master/CHANGELOG.md
- `npm run sort-bindings` is run to ensure the bindings are sorted
  (if you are contributing updates to bindings)
-->
