### PR TITLE
Add binding to show error message under cursor 'SPC e e'

### DIFF
--- a/package.json
+++ b/package.json
@@ -812,6 +812,13 @@
 										"type": "transient",
 										"bindings": [
 											{
+												"key": "e",
+												"name": "Show error",
+												"icon": "error",
+												"type": "command",
+												"command": "editor.action.showHover"
+											},
+											{
 												"key": "n",
 												"name": "Next error",
 												"icon": "arrow-down",
@@ -833,6 +840,13 @@
 												"command": "editor.action.marker.prevInFiles"
 											}
 										]
+									},
+									{
+										"key": "e",
+										"name": "Show error",
+										"icon": "error",
+										"type": "command",
+										"command": "editor.action.showHover"
 									},
 									{
 										"key": "l",


### PR DESCRIPTION
<!-- Please explain the changes you made -->

<!--
Please, make sure:
- you have read the contributing guidelines:
  https://github.com/VSpaceCode/VSpaceCode/blob/master/CONTRIBUTING.md
- you have updated the changelog (if needed):
  https://github.com/VSpaceCode/VSpaceCode/blob/master/CHANGELOG.md
- `npm run sort-bindings` is run to ensure the bindings are sorted
  (if you are contributing updates to bindings)
-->