### PR TITLE
Add bindings to show and fix errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,7 +25,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - `SPC : t` to run test task
   - `SPC : :` to run task
   - `SPC : R` to restart running task
-- Add `<SPC> e f` to fix an error
+- Add error-related bindings
+  - `<SPC> e e` to show an error
+  - `<SPC> e f` to fix an error
 - Add additional bindings in Rust major mode
   - "+Action" menu (`<SPC> m a`):
     - `<SPC> m a a` to execute code action

--- a/package.json
+++ b/package.json
@@ -885,7 +885,7 @@
 										"bindings": [
 											{
 												"key": "f",
-												"name": "Fix",
+												"name": "Fix error",
 												"icon": "lightbulb-autofix",
 												"type": "command",
 												"command": "editor.action.quickFix"
@@ -914,8 +914,15 @@
 										]
 									},
 									{
+										"key": "e",
+										"name": "Show error",
+										"icon": "error",
+										"type": "command",
+										"command": "editor.action.showHover"
+									},
+									{
 										"key": "f",
-										"name": "Fix",
+										"name": "Fix error",
 										"icon": "lightbulb-autofix",
 										"type": "command",
 										"command": "editor.action.quickFix"


### PR DESCRIPTION
  - `<SPC> e e` to show an error
  - `<SPC> e f` to fix an error

Combine these PRs because they will conflict if merged separately. 
- https://github.com/VSpaceCode/VSpaceCode/pull/233
- https://github.com/VSpaceCode/VSpaceCode/pull/234