### PR TITLE
Add a major mode for the Coq language

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Add basic major modes bindings for JavaScript/TypeScript
 - Add major mode for Julia
+- Add major mode for Coq
 
 ### Changed
 

--- a/package.json
+++ b/package.json
@@ -2128,6 +2128,248 @@
 										]
 									},
 									{
+										"key": "languageId:coq",
+										"name": "coq",
+										"type": "bindings",
+										"bindings": [
+											{
+												"key": ".",
+												"name": "Proof goto current point",
+												"icon": "debug-start",
+												"type": "command",
+												"command": "extension.coq.interpretToPoint"
+											},
+											{
+												"key": "b",
+												"name": "Proof step back",
+												"icon": "debug-step-back",
+												"type": "command",
+												"command": "extension.coq.stepBackward"
+											},
+											{
+												"key": "f",
+												"name": "Proof step forward",
+												"icon": "debug-step-over",
+												"type": "command",
+												"command": "extension.coq.stepForward"
+											},
+											{
+												"key": "g",
+												"name": "Go to the current focus location",
+												"icon": "sync",
+												"type": "command",
+												"command": "extension.coq.moveCursorToFocus"
+											},
+											{
+												"key": "o",
+												"name": "Open proof view",
+												"icon": "open-preview",
+												"type": "command",
+												"command": "extension.coq.proofView.open"
+											},
+											{
+												"key": "v",
+												"name": "View the proof-state at the cursor position",
+												"icon": "eye",
+												"type": "command",
+												"command": "extension.coq.proofView.viewStateAt"
+											},
+											{
+												"key": "G",
+												"name": "Proof goto end",
+												"icon": "debug-continue",
+												"type": "command",
+												"command": "extension.coq.interpretToEnd"
+											},
+											{
+												"key": "a",
+												"name": "Ask prover",
+												"icon": "question",
+												"type": "bindings",
+												"bindings": [
+													{
+														"key": "a",
+														"name": "About",
+														"icon": "info",
+														"type": "command",
+														"command": "extension.coq.query.prompt.about"
+													},
+													{
+														"key": "c",
+														"name": "Check",
+														"icon": "check",
+														"type": "command",
+														"command": "extension.coq.query.prompt.check"
+													},
+													{
+														"key": "l",
+														"name": "Locate",
+														"icon": "location",
+														"type": "command",
+														"command": "extension.coq.query.prompt.locate"
+													},
+													{
+														"key": "p",
+														"name": "Print",
+														"icon": "eye",
+														"type": "command",
+														"command": "extension.coq.query.prompt.print"
+													},
+													{
+														"key": "s",
+														"name": "Search",
+														"icon": "search",
+														"type": "command",
+														"command": "extension.coq.query.prompt.search"
+													}
+												]
+											},
+											{
+												"key": "p",
+												"name": "Send command to prover",
+												"icon": "console",
+												"type": "bindings",
+												"bindings": [
+													{
+														"key": "f",
+														"name": "Finish coq computations",
+														"icon": "notebook-state-success",
+														"type": "command",
+														"command": "extension.coq.finishComputations"
+													},
+													{
+														"key": "i",
+														"name": "Interrupt coqtop backend",
+														"icon": "notebook-stop",
+														"type": "command",
+														"command": "extension.coq.interrupt"
+													},
+													{
+														"key": "q",
+														"name": "Quit coqtop backend",
+														"icon": "panel-close",
+														"type": "command",
+														"command": "extension.coq.quit"
+													},
+													{
+														"key": "r",
+														"name": "Reset coqtop backend",
+														"icon": "notebook-delete-cell",
+														"type": "command",
+														"command": "extension.coq.reset"
+													}
+												]
+											},
+											{
+												"key": "q",
+												"name": "Query prover about foucsed symbol",
+												"icon": "info",
+												"type": "bindings",
+												"bindings": [
+													{
+														"key": "a",
+														"name": "About",
+														"icon": "info",
+														"type": "command",
+														"command": "extension.coq.query.about"
+													},
+													{
+														"key": "c",
+														"name": "Check",
+														"icon": "check",
+														"type": "command",
+														"command": "extension.coq.query.check"
+													},
+													{
+														"key": "l",
+														"name": "Locate",
+														"icon": "location",
+														"type": "command",
+														"command": "extension.coq.query.locate"
+													},
+													{
+														"key": "p",
+														"name": "Print",
+														"icon": "eye",
+														"type": "command",
+														"command": "extension.coq.query.print"
+													},
+													{
+														"key": "s",
+														"name": "Search",
+														"icon": "search",
+														"type": "command",
+														"command": "extension.coq.query.search"
+													}
+												]
+											},
+											{
+												"key": "s",
+												"name": "Set display options",
+												"icon": "gear",
+												"type": "bindings",
+												"bindings": [
+													{
+														"key": "b",
+														"name": "Display all basic low level contents on/off",
+														"icon": "symbol-interface",
+														"type": "command",
+														"command": "extension.coq.display.toggle.allBasicLowLevelContents"
+													},
+													{
+														"key": "c",
+														"name": "Display coercions on/off",
+														"icon": "symbol-enum",
+														"type": "command",
+														"command": "extension.coq.display.toggle.coercions"
+													},
+													{
+														"key": "e",
+														"name": "Display existential variable instances on/off",
+														"icon": "symbol-keyword",
+														"type": "command",
+														"command": "extension.coq.display.toggle.existentialVariableInstances"
+													},
+													{
+														"key": "i",
+														"name": "Display implicit arguments on/off",
+														"icon": "symbol-parameter",
+														"type": "command",
+														"command": "extension.coq.display.toggle.implicitArguments"
+													},
+													{
+														"key": "l",
+														"name": "Display all lowLevel contents on/off",
+														"type": "command",
+														"icon": "symbol-constant",
+														"command": "extension.coq.display.toggle.allLowLevelContents"
+													},
+													{
+														"key": "n",
+														"name": "Display notations on/off",
+														"icon": "symbol-key",
+														"type": "command",
+														"command": "extension.coq.display.toggle.notations"
+													},
+													{
+														"key": "r",
+														"name": "Display raw matching expressions on/off",
+														"icon": "symbol-constructor",
+														"type": "command",
+														"command": "extension.coq.display.toggle.rawMatchingExpressions"
+													},
+													{
+														"key": "u",
+														"name": "Display universe levels on/off",
+														"icon": "symbol-module",
+														"type": "command",
+														"command": "extension.coq.display.toggle.universeLevels"
+													}
+												]
+											}
+										]
+									},
+									{
 										"key": "languageId:cpp",
 										"name": "C++",
 										"type": "bindings",

--- a/package.json
+++ b/package.json
@@ -2202,6 +2202,13 @@
 														"command": "extension.coq.query.prompt.check"
 													},
 													{
+														"key": "f",
+														"name": "Find",
+														"icon": "search",
+														"type": "command",
+														"command": "extension.coq.query.prompt.search"
+													},
+													{
 														"key": "l",
 														"name": "Locate",
 														"icon": "location",
@@ -2214,13 +2221,6 @@
 														"icon": "eye",
 														"type": "command",
 														"command": "extension.coq.query.prompt.print"
-													},
-													{
-														"key": "s",
-														"name": "Search",
-														"icon": "search",
-														"type": "command",
-														"command": "extension.coq.query.prompt.search"
 													}
 												]
 											},
@@ -2281,6 +2281,13 @@
 														"command": "extension.coq.query.check"
 													},
 													{
+														"key": "f",
+														"name": "Find",
+														"icon": "search",
+														"type": "command",
+														"command": "extension.coq.query.search"
+													},
+													{
 														"key": "l",
 														"name": "Locate",
 														"icon": "location",
@@ -2293,74 +2300,67 @@
 														"icon": "eye",
 														"type": "command",
 														"command": "extension.coq.query.print"
-													},
-													{
-														"key": "s",
-														"name": "Search",
-														"icon": "search",
-														"type": "command",
-														"command": "extension.coq.query.search"
 													}
 												]
 											},
 											{
-												"key": "s",
-												"name": "Set display options",
+												"key": "T",
+												"name": "UI toggle",
 												"icon": "gear",
 												"type": "bindings",
 												"bindings": [
 													{
 														"key": "b",
-														"name": "Display all basic low level contents on/off",
+														"name": "Toggle display of all basic low level contents",
 														"icon": "symbol-interface",
 														"type": "command",
 														"command": "extension.coq.display.toggle.allBasicLowLevelContents"
 													},
 													{
 														"key": "c",
-														"name": "Display coercions on/off",
+														"name": "Toggle display of coercions",
 														"icon": "symbol-enum",
 														"type": "command",
 														"command": "extension.coq.display.toggle.coercions"
 													},
 													{
 														"key": "e",
-														"name": "Display existential variable instances on/off",
+														"name": "Toggle display of existential variable instances",
 														"icon": "symbol-keyword",
 														"type": "command",
 														"command": "extension.coq.display.toggle.existentialVariableInstances"
 													},
 													{
 														"key": "i",
-														"name": "Display implicit arguments on/off",
+														"name": "Toggle display of implicit arguments",
 														"icon": "symbol-parameter",
 														"type": "command",
 														"command": "extension.coq.display.toggle.implicitArguments"
 													},
 													{
 														"key": "l",
-														"name": "Display all lowLevel contents on/off",
+														"name": "Toggle display of all lowLevel contents",
 														"type": "command",
 														"icon": "symbol-constant",
 														"command": "extension.coq.display.toggle.allLowLevelContents"
 													},
 													{
 														"key": "n",
-														"name": "Display notations on/off",
+														"name": "Toggle display of notations",
 														"icon": "symbol-key",
 														"type": "command",
 														"command": "extension.coq.display.toggle.notations"
 													},
 													{
 														"key": "r",
-														"name": "Display raw matching expressions on/off",
+														"name": "Toggle display of raw matching expressions",
 														"icon": "symbol-constructor",
 														"type": "command",
 														"command": "extension.coq.display.toggle.rawMatchingExpressions"
 													},
 													{
 														"key": "u",
-														"name": "Display universe levels on/off",
+														"name": "Toggle display of universe levels",
 														"icon": "symbol-module",
 														"type": "command",
 														"command": "extension.coq.display.toggle.universeLevels"


### PR DESCRIPTION
Major mode for coq, based on the [vscoq](https://github.com/ayanamists/vscoq) extension. It's not very similar to the spacemacs [coq layer](https://develop.spacemacs.org/layers/+lang/coq/README.html), because the ability of vscoq is different to coq layer.

Known Problems:

+ `proof-goto-point` will goto the previous tactic when cursor is at the `.` symbol. This is caused by `extension.coq.interpretToPoint` command of vscoq