### PR TITLE
Replace the `python.refactorExtract{Method,Variable}` commands with working commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Python major mode:
+  - `SPC m r m` and `SPC m r v` commands have been removed, as they no longer do anything.
+  - `SPC m r .` has been added in their stead, which now invokes the built-in refactor methods.
+
 ## [0.10.6] - 2022-01-23
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -5863,18 +5863,11 @@
 												"type": "bindings",
 												"bindings": [
 													{
-														"key": "m",
-														"name": "Extract method",
-														"icon": "symbol-method",
+														"key": ".",
+														"name": "Refactor menu",
+														"icon": "lightbulb",
 														"type": "command",
-														"command": "python.refactorExtractMethod"
-													},
-													{
-														"key": "v",
-														"name": "Extract variable",
-														"icon": "variable",
-														"type": "command",
-														"command": "python.refactorExtractVariable"
+														"command": "editor.action.refactor"
 													},
 													{
 														"key": "I",


### PR DESCRIPTION
<!-- Please explain the changes you made -->

<!--
Please, make sure:
- you have read the contributing guidelines:
  https://github.com/VSpaceCode/VSpaceCode/blob/master/CONTRIBUTING.md
- you have updated the changelog (if needed):
  https://github.com/VSpaceCode/VSpaceCode/blob/master/CHANGELOG.md
- `npm run sort-bindings` is run to ensure the bindings are sorted
  (if you are contributing updates to bindings)
-->

At some point, the `python.refactorExtract{Method,Variable}` commands were removed from the Python extension. Not sure when. This replaced those commands with the generic "refactor" menu invocation.

I'm not totally against just removing these two commands entirely and only add things that are unique to the Python major mode, but I figured this would be good for redundancy/muscle memory.