### PR TITLE
Add ctrl+j/k for File Explorer

### DIFF
--- a/src/configuration/keybindings.jsonc
+++ b/src/configuration/keybindings.jsonc
@@ -119,6 +119,17 @@
         "command": "showPrevParameterHint",
         "when": "editorFocus && parameterHintsMultipleSignatures && parameterHintsVisible"
     },
+    // File Explorer navigation with ctrl+h/k
+    {
+        "key": "ctrl+j",
+        "command": "list.focusDown",
+        "when": "explorerViewletVisible && filesExplorerFocus && !explorerResourceIsRoot && !explorerResourceReadonly && !inputFocus"
+    },
+    {
+         "key": "ctrl+k",
+         "command": "list.focusUp",
+         "when": "explorerViewletVisible && filesExplorerFocus && !explorerResourceIsRoot && !explorerResourceReadonly && !inputFocus"
+     },
     // Add ctrl+h/l to navigate in file browser
     {
         "key": "ctrl+h",


### PR DESCRIPTION
Navigate with ctrl+j/k in File Explorer

<!--
Please, make sure:
- you have read the contributing guidelines:
  https://github.com/VSpaceCode/VSpaceCode/blob/master/CONTRIBUTING.md
- you have updated the changelog (if needed):
  https://github.com/VSpaceCode/VSpaceCode/blob/master/CHANGELOG.md
- `npm run sort-bindings` is run to ensure the bindings are sorted
  (if you are contributing updates to bindings)
-->
