### PR TITLE
Fix duplicate command label in Clojure mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Clojure major mode: fix duplicate command name – ` SPC m e l` (`calva.clearInlineResults`) is now named "Clear inline evaluation results"
+- Clojure major mode: fix duplicate command name – `SPC m e l` (`calva.clearInlineResults`) is now named "Clear inline evaluation results"
 
 ## [0.10.9] - 2022-04-03
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,9 +13,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## Added
+### Added
 
 -   ⌨️ Add `ctrl+j/k/l` as a shortcut to traverse items in code action
+
+### Fixed
+
+- Clojure major mode: fix duplicate command name – ` SPC m e l` (`calva.clearInlineResults`) is now named "Clear inline evaluation results"
 
 ## [0.10.9] - 2022-04-03
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Clojure major mode: fix duplicate command name – `SPC m e l` (`calva.clearInlineResults`) is now named "Clear inline evaluation results"
+-   Clojure major mode: fix duplicate command name – `SPC m e l` (`calva.clearInlineResults`) is now named "Clear inline evaluation results"
 
 ## [0.10.9] - 2022-04-03
 

--- a/package.json
+++ b/package.json
@@ -1857,7 +1857,7 @@
                                                     },
                                                     {
                                                         "key": "l",
-                                                        "name": "Clear evaluation results",
+                                                        "name": "Clear inline evaluation results",
                                                         "type": "command",
                                                         "command": "calva.clearInlineResults"
                                                     },


### PR DESCRIPTION
<!-- Please explain the changes you made -->
There are two different commands with the same label `Clear evaluation results`. This resolves the ambiguity by relabeling the binding for command `calva.clearInlineResults`.
<!--
Please, make sure:
- you have read the contributing guidelines:
  https://github.com/VSpaceCode/VSpaceCode/blob/master/CONTRIBUTING.md
- you have updated the changelog (if needed):
  https://github.com/VSpaceCode/VSpaceCode/blob/master/CHANGELOG.md
- `npm run sort-bindings` is run to ensure the bindings are sorted
  (if you are contributing updates to bindings)
-->
