### PR TITLE
Change `SPC f R` to use file-browser's rename

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 -   ⌨️ Add `ctrl+j/k/l` as a shortcut to traverse items in code action
 
+### Changed
+
+-   Change `SPC f R` to use file-browser's rename
+
 ## [0.10.9] - 2022-04-03
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1060,11 +1060,8 @@
                                         "key": "R",
                                         "name": "Rename file",
                                         "icon": "edit",
-                                        "type": "commands",
-                                        "commands": [
-                                            "workbench.files.action.showActiveFileInExplorer",
-                                            "renameFile"
-                                        ]
+                                        "type": "command",
+                                        "command": "file-browser.rename"
                                     },
                                     {
                                         "key": "S",


### PR DESCRIPTION
Fixed #134.

As file-browser added separate command for rename in https://github.com/bodil/vscode-file-browser/pull/27 and released v0.2.11, we can use that command instead of the built-in one.