### PR TITLE
fix: improve `SPC f R` file rename

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 -   Clojure major mode: fix duplicate command name – `SPC m e l` (`calva.clearInlineResults`) is now named "Clear inline evaluation results"
+-   Improve `SPC f R`. Now it works more consistently.
 
 ## [0.10.9] - 2022-04-03
 

--- a/package.json
+++ b/package.json
@@ -1062,7 +1062,7 @@
                                         "icon": "edit",
                                         "type": "commands",
                                         "commands": [
-                                            "workbench.files.action.showActiveFileInExplorer",
+                                            "revealInExplorer",
                                             "renameFile"
                                         ]
                                     },


### PR DESCRIPTION
I found this works better.

## How to reproduce a case where this works better

1. open a file
2. open the extensions panel
3. restart VSCode
4. Press `SPC f R`

For me, this doesn't work with the current setup. But it works with the new one.
