### PR TITLE
feat: `SPC b R` reverts buffer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## Added
 
 -   ⌨️ Add `ctrl+j/k/l` as a shortcut to traverse items in code action
--    Add `SPC b R` to revert current buffer
+-   Add `SPC b R` to revert current buffer. You can use it to discard unsaved changes.
 
 ## [0.10.9] - 2022-04-03
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## Added
 
 -   ⌨️ Add `ctrl+j/k/l` as a shortcut to traverse items in code action
+-   Add `SPC b R` to revert current buffer (reload from disk)
 
 ## [0.10.9] - 2022-04-03
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## Added
 
 -   ⌨️ Add `ctrl+j/k/l` as a shortcut to traverse items in code action
--   Add `SPC b R` to revert current buffer (reload from disk)
+-   ⌨ Add `SPC b R` to revert current buffer (reload from disk)
 
 ## [0.10.9] - 2022-04-03
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## Added
 
 -   ⌨️ Add `ctrl+j/k/l` as a shortcut to traverse items in code action
--   ⌨ Add `SPC b R` to revert current buffer (reload from disk)
+-    Add `SPC b R` to revert current buffer
 
 ## [0.10.9] - 2022-04-03
 

--- a/package.json
+++ b/package.json
@@ -539,7 +539,7 @@
                                     },
                                     {
                                         "key": "R",
-                                        "name": "Revert the current buffer (reload from disk)",
+                                        "name": "Revert the current buffer",
                                         "icon": "discard",
                                         "type": "command",
                                         "command": "workbench.action.files.revert"

--- a/package.json
+++ b/package.json
@@ -538,6 +538,13 @@
                                         ]
                                     },
                                     {
+                                        "key": "R",
+                                        "name": "Revert the current buffer (reload from disk)",
+                                        "icon": "discard",
+                                        "type": "command",
+                                        "command": "workbench.action.files.revert"
+                                    },
+                                    {
                                         "key": "T",
                                         "name": "Unpin buffer",
                                         "icon": "pinned",


### PR DESCRIPTION
<!-- Please explain the changes you made -->

<!--
Please, make sure:
- you have read the contributing guidelines:
  https://github.com/VSpaceCode/VSpaceCode/blob/master/CONTRIBUTING.md
- you have updated the changelog (if needed):
  https://github.com/VSpaceCode/VSpaceCode/blob/master/CHANGELOG.md
- `npm run sort-bindings` is run to ensure the bindings are sorted
  (if you are contributing updates to bindings)
-->

Also present in [spacemacs](https://develop.spacemacs.org/doc/DOCUMENTATION.html#buffers-manipulation-key-bindings)
