### PR TITLE
Add confirmation to configuration commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 -   ⌨️ Add `ctrl+j/k/l` as a shortcut to traverse items in code action
 -   Add `SPC b R` to revert current buffer. You can use it to discard unsaved changes.
+-   Add confirmation for configuration commands
 
 ### Fixed
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -18,7 +18,13 @@ import {
     GlobalState,
     WalkthroughId,
 } from "./constants";
-import { showUpdateMessage } from "./messages";
+import {
+    configConfirmTitle,
+    configKeybindingsConfirmTitle,
+    configSettingsConfirmTitle,
+    confirmWrapper,
+    showUpdateMessage,
+} from "./messages";
 import {
     copyWrapper,
     getDirectoryPath,
@@ -65,15 +71,21 @@ export async function activate(context: ExtensionContext) {
     );
 
     context.subscriptions.push(
-        commands.registerCommand(CommandId.Configure, configure)
+        commands.registerCommand(
+            CommandId.Configure,
+            confirmWrapper(configConfirmTitle, configure)
+        )
     );
     context.subscriptions.push(
-        commands.registerCommand(CommandId.ConfigureSettings, configSettings)
+        commands.registerCommand(
+            CommandId.ConfigureSettings,
+            confirmWrapper(configSettingsConfirmTitle, configSettings)
+        )
     );
     context.subscriptions.push(
         commands.registerCommand(
             CommandId.ConfigureKeybindings,
-            configKeyBindings
+            confirmWrapper(configKeybindingsConfirmTitle, configKeyBindings)
         )
     );
 
@@ -178,10 +190,7 @@ function showMagitRefMenu() {
 }
 
 function configure() {
-    return Promise.all([
-        commands.executeCommand(CommandId.ConfigureSettings),
-        commands.executeCommand(CommandId.ConfigureKeybindings),
-    ]);
+    return Promise.all([configSettings, configKeyBindings]);
 }
 
 function openDocumentationUrl() {

--- a/src/messages.ts
+++ b/src/messages.ts
@@ -1,6 +1,27 @@
 import { env, Uri, window } from "vscode";
 import { ComparisonResult, Version } from "./version";
 
+export const configSettingsConfirmTitle =
+    "Configuring settings may change the format of your settings.json file. Are you sure?";
+export const configKeybindingsConfirmTitle =
+    "Configuring keybindings may change the format of your keybindngs.json file. Are you sure?";
+export const configConfirmTitle =
+    "Configuration may change the format of your keybindngs.json file. Are you sure? ";
+
+export function confirmWrapper(title: string, fn: () => Thenable<any>) {
+    return async () => {
+        const confirmText = "Sure";
+        const cancelText = "Cancel";
+        const selection = await window.showQuickPick(
+            [confirmText, cancelText],
+            { title }
+        );
+        if (selection === confirmText) {
+            await fn();
+        }
+    };
+}
+
 export async function showUpdateMessage(cur: string, prev: string) {
     if (Version.compare(cur, prev) === ComparisonResult.Newer) {
         const changeLog = "Changelog";


### PR DESCRIPTION
This PR adds confirmation to the configuration commands as follows. It is stacked on top of https://github.com/VSpaceCode/VSpaceCode/pull/291 for. (no stacked PR in GH 🤦‍♂️)

<img width="609" alt="image" src="https://user-images.githubusercontent.com/3455662/203233664-74eea258-3e27-48f4-aa76-51573dce155d.png">