### PR TITLE
Use built-in command for visual mode indention

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 -   Add `SPC T M` to toggle minimap.
+-   ⚙ Use built-in command for visual mode indention
 
 ## [0.10.14] - 2023-02-10
 

--- a/src/configuration/settings.jsonc
+++ b/src/configuration/settings.jsonc
@@ -37,6 +37,14 @@
                     "args": "m"
                 }
             ]
+        },
+        {
+            "before": [">"],
+            "commands": ["editor.action.indentLines"]
+        },
+        {
+            "before": ["<"],
+            "commands": ["editor.action.outdentLines"]
         }
     ]
 }


### PR DESCRIPTION
This is to emulate the same behavior as spacemacs where indent and outdent will not exit visual mode. However, it is known that this will cause `.` not work.

Fixes #317