### PR TITLE
Add more jump to buffer at idx shortcuts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 -   Add `SPC T M` to toggle minimap.
 -   ⚙ Use built-in command for visual mode indention
+-   Added `SPC b <int>` commands for jumping to buffers 0-9
 
 ## [0.10.14] - 2023-02-10
 

--- a/package.json
+++ b/package.json
@@ -406,7 +406,63 @@
                                         "name": "First buffer in window",
                                         "icon": "arrow-both",
                                         "type": "command",
-                                        "command": "workbench.action.firstEditorInGroup"
+                                        "command": "workbench.action.openEditorAtIndex1"
+                                    },
+                                    {
+                                        "key": "2",
+                                        "name": "2nd buffer in window",
+                                        "icon": "arrow-both",
+                                        "type": "command",
+                                        "command": "workbench.action.openEditorAtIndex2"
+                                    },
+                                    {
+                                        "key": "3",
+                                        "name": "3rd buffer in window",
+                                        "icon": "arrow-both",
+                                        "type": "command",
+                                        "command": "workbench.action.openEditorAtIndex3"
+                                    },
+                                    {
+                                        "key": "4",
+                                        "name": "4th buffer in window",
+                                        "icon": "arrow-both",
+                                        "type": "command",
+                                        "command": "workbench.action.openEditorAtIndex4"
+                                    },
+                                    {
+                                        "key": "5",
+                                        "name": "5th buffer in window",
+                                        "icon": "arrow-both",
+                                        "type": "command",
+                                        "command": "workbench.action.openEditorAtIndex5"
+                                    },
+                                    {
+                                        "key": "6",
+                                        "name": "6th buffer in window",
+                                        "icon": "arrow-both",
+                                        "type": "command",
+                                        "command": "workbench.action.openEditorAtIndex6"
+                                    },
+                                    {
+                                        "key": "7",
+                                        "name": "7th buffer in window",
+                                        "icon": "arrow-both",
+                                        "type": "command",
+                                        "command": "workbench.action.openEditorAtIndex7"
+                                    },
+                                    {
+                                        "key": "8",
+                                        "name": "8th buffer in window",
+                                        "icon": "arrow-both",
+                                        "type": "command",
+                                        "command": "workbench.action.openEditorAtIndex8"
+                                    },
+                                    {
+                                        "key": "9",
+                                        "name": "9th buffer in window",
+                                        "icon": "arrow-both",
+                                        "type": "command",
+                                        "command": "workbench.action.openEditorAtIndex9"
                                     },
                                     {
                                         "key": "b",


### PR DESCRIPTION
<!-- Please explain the changes you made -->

VScode already has a shortcut for this at `CTRL+<idx>` but that's not very discoverable.

<!--
Please, make sure:
- you have read the contributing guidelines:
  https://github.com/VSpaceCode/VSpaceCode/blob/master/CONTRIBUTING.md
- you have updated the changelog (if needed):
  https://github.com/VSpaceCode/VSpaceCode/blob/master/CHANGELOG.md
- `npm run sort-bindings` is run to ensure the bindings are sorted
  (if you are contributing updates to bindings)
-->
