### PR TITLE
Align with VSCodeVim's window navigation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+-   Align with VSCodeVim's window navigation
+
 ## [0.10.15] - 2023-09-23
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
--   Align with VSCodeVim's window navigation
+-   `SPC w` + `h`, `j`, `k`, `l` navigate to the expected direction
 
 ## [0.10.15] - 2023-09-23
 

--- a/package.json
+++ b/package.json
@@ -8417,28 +8417,28 @@
                                         "name": "Focus window left",
                                         "icon": "arrow-left",
                                         "type": "command",
-                                        "command": "workbench.action.focusPreviousGroup"
+                                        "command": "workbench.action.navigateLeft"
                                     },
                                     {
                                         "key": "j",
                                         "name": "Focus window down",
                                         "icon": "arrow-down",
                                         "type": "command",
-                                        "command": "workbench.action.focusBelowGroup"
+                                        "command": "workbench.action.navigateDown"
                                     },
                                     {
                                         "key": "k",
                                         "name": "Focus window up",
                                         "icon": "arrow-up",
                                         "type": "command",
-                                        "command": "workbench.action.focusAboveGroup"
+                                        "command": "workbench.action.navigateUp"
                                     },
                                     {
                                         "key": "l",
                                         "name": "Focus window right",
                                         "icon": "arrow-right",
                                         "type": "command",
-                                        "command": "workbench.action.focusNextGroup"
+                                        "command": "workbench.action.navigateRight"
                                     },
                                     {
                                         "key": "m",


### PR DESCRIPTION
<!-- Please explain the changes you made -->
Currently, focus left and focus right doesn't respect "left" and "right" directions. It just goes anticlockwise and clockwise navigation.

With this change, now it aligns well with expected behavior, left and right wise window movement.

<!--
Please, make sure:
- you have read the contributing guidelines:
  https://github.com/VSpaceCode/VSpaceCode/blob/master/CONTRIBUTING.md
- you have updated the changelog (if needed):
  https://github.com/VSpaceCode/VSpaceCode/blob/master/CHANGELOG.md
- `npm run sort-bindings` is run to ensure the bindings are sorted
  (if you are contributing updates to bindings)
-->
