### PR TITLE
Fix maximize window behavior

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 -   `SPC w` + `h`, `j`, `k`, `l` navigate to the expected direction
+-   `SPC w m` maximizes the window as expected, while `SPC w M` changes to maximize the window without hiding other windows
 
 ## [0.10.15] - 2023-09-23
 

--- a/package.json
+++ b/package.json
@@ -8445,7 +8445,7 @@
                                         "name": "Maximize window",
                                         "icon": "chrome-maximize",
                                         "type": "command",
-                                        "command": "workbench.action.toggleEditorWidths"
+                                        "command": "workbench.action.toggleMaximizeEditorGroup"
                                     },
                                     {
                                         "key": "o",
@@ -8533,10 +8533,10 @@
                                     },
                                     {
                                         "key": "M",
-                                        "name": "Maximize window and hide side bar",
+                                        "name": "Maximize window without hiding others",
                                         "icon": "screen-full",
                                         "type": "command",
-                                        "command": "workbench.action.maximizeEditor"
+                                        "command": "workbench.action.toggleEditorWidths"
                                     },
                                     {
                                         "key": "W",


### PR DESCRIPTION
<!-- Please explain the changes you made -->

`SPC w m` maximizes the window as expected, while `SPC w M` changes to maximize the window without hiding other windows.

fix #316 

<!--
Please, make sure:
- you have read the contributing guidelines:
  https://github.com/VSpaceCode/VSpaceCode/blob/master/CONTRIBUTING.md
- you have updated the changelog (if needed):
  https://github.com/VSpaceCode/VSpaceCode/blob/master/CHANGELOG.md
- `npm run sort-bindings` is run to ensure the bindings are sorted
  (if you are contributing updates to bindings)
-->
