### PR TITLE
Edamagit bindings template update

### DIFF
--- a/src/configuration/keybindings.jsonc
+++ b/src/configuration/keybindings.jsonc
@@ -15,6 +15,16 @@
     // https://github.com/kahole/edamagit#vim-support-vscodevim
     // Cannot be added to package.json because keybinding replacements
     {
+        "key": "g g",
+        "command": "cursorTop",
+        "when": "editorTextFocus && editorLangId == 'magit' && vim.mode =~ /^(?!SearchInProgressMode|CommandlineInProgress).*$/"
+    },
+    {
+        "key": "g r",
+        "command": "magit.refresh",
+        "when": "editorTextFocus && editorLangId == 'magit' && vim.mode =~ /^(?!SearchInProgressMode|CommandlineInProgress).*$/"
+    },
+    {
         "key": "tab",
         "command": "extension.vim_tab",
         "when": "editorTextFocus && vim.active && !inDebugRepl && vim.mode != 'Insert' && editorLangId != 'magit'"

--- a/src/configuration/keybindings.jsonc
+++ b/src/configuration/keybindings.jsonc
@@ -17,12 +17,12 @@
     {
         "key": "tab",
         "command": "extension.vim_tab",
-        "when": "editorFocus && vim.active && !inDebugRepl && vim.mode != 'Insert' && editorLangId != 'magit'"
+        "when": "editorTextFocus && vim.active && !inDebugRepl && vim.mode != 'Insert' && editorLangId != 'magit'"
     },
     {
         "key": "tab",
         "command": "-extension.vim_tab",
-        "when": "editorFocus && vim.active && !inDebugRepl && vim.mode != 'Insert'"
+        "when": "editorTextFocus && vim.active && !inDebugRepl && vim.mode != 'Insert'"
     },
     {
         "key": "x",


### PR DESCRIPTION
The edamagit section of the keybindings template had some broken entries (already fixed/updated upstream).
This PR brings those fixes plus the remaining new bindings - all from the same source referred on the file.

#### feat(edamagit): add top and refresh bindings <sup>f6bdb4c</sup>

#### fix(edamagit): editorFocus -> editorTextFocus on TAB <sup>d760876</sup>
Fixes: #336
Ref: kahole/edamagit#274

Thanks for VSpaceCode! 🥳 