### PR TITLE
Add whichkey menu for `g` in magit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+-   ⌨ Added whichkey menu for `g` in magit buffer which supports `g g` to move cursor to the top.
+
 ### Changed
 
 -   `SPC w` + `h`, `j`, `k`, `l` navigate to the expected direction

--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
         "onStartupFinished",
         "onCommand:vspacecode.space",
         "onCommand:vspacecode.showMagitRefMenu",
+        "onCommand:vspacecode.showMagitRefreshMenu",
         "onCommand:vspacecode.configure",
         "onCommand:vspacecode.configureSettings",
         "onCommand:vspacecode.configureKeybindings",
@@ -70,6 +71,11 @@
             {
                 "command": "vspacecode.showMagitRefMenu",
                 "title": "Show Magit Ref Menu",
+                "category": "VSpaceCode"
+            },
+            {
+                "command": "vspacecode.showMagitRefreshMenu",
+                "title": "Show Magit Refresh Menu",
                 "category": "VSpaceCode"
             },
             {
@@ -146,6 +152,26 @@
                                         "y"
                                     ]
                                 }
+                            }
+                        ]
+                    },
+                    "vspacecode.magitRefreshBindings": {
+                        "type": "array",
+                        "markdownDescription": "The bindings of magit refresh menu",
+                        "default": [
+                            {
+                                "key": "g",
+                                "name": "Go cursor to top",
+                                "icon": "arrow-up",
+                                "type": "command",
+                                "command": "cursorTop"
+                            },
+                            {
+                                "key": "r",
+                                "name": "Refresh magit buffer",
+                                "icon": "refresh",
+                                "type": "command",
+                                "command": "magit.refresh"
                             }
                         ]
                     },

--- a/src/configuration/keybindings.jsonc
+++ b/src/configuration/keybindings.jsonc
@@ -15,16 +15,6 @@
     // https://github.com/kahole/edamagit#vim-support-vscodevim
     // Cannot be added to package.json because keybinding replacements
     {
-        "key": "g g",
-        "command": "cursorTop",
-        "when": "editorTextFocus && editorLangId == 'magit' && vim.mode =~ /^(?!SearchInProgressMode|CommandlineInProgress).*$/"
-    },
-    {
-        "key": "g r",
-        "command": "magit.refresh",
-        "when": "editorTextFocus && editorLangId == 'magit' && vim.mode =~ /^(?!SearchInProgressMode|CommandlineInProgress).*$/"
-    },
-    {
         "key": "tab",
         "command": "extension.vim_tab",
         "when": "editorTextFocus && vim.active && !inDebugRepl && vim.mode != 'Insert' && editorLangId != 'magit'"
@@ -88,6 +78,18 @@
         "key": "y",
         "command": "vspacecode.showMagitRefMenu",
         "when": "editorTextFocus && editorLangId == 'magit' && vim.mode == 'Normal'"
+    },
+    // Extra refresh menu support for edamagit with the key "g"
+    // Cannot be added to package.json because keybinding replacements
+    {
+        "key": "g",
+        "command": "-magit.refresh",
+        "when": "editorTextFocus && editorLangId == 'magit' && vim.mode =~ /^(?!SearchInProgressMode|CommandlineInProgress).*$/"
+    },
+    {
+        "key": "g",
+        "command": "vspacecode.showMagitRefreshMenu",
+        "when": "editorTextFocus && editorLangId == 'magit' && vim.mode =~ /^(?!SearchInProgressMode|CommandlineInProgress).*$/"
     },
     // Easy navigation in quick open/QuickPick
     {

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -5,6 +5,7 @@ export const spaceCmdId = `${extensionId}.space`;
 export enum CommandId {
     ShowSpaceMenu = "vspacecode.space",
     ShowMagitRefMenu = "vspacecode.showMagitRefMenu",
+    ShowMagitRefreshMenu = "vspacecode.showMagitRefreshMenu",
 
     Configure = "vspacecode.configure",
     ConfigureSettings = "vspacecode.configureSettings",
@@ -39,12 +40,14 @@ export enum ConfigKey {
     Bindings = "bindings",
     Overrides = "bindingOverrides",
     RefBindings = "magitRefBindings",
+    RefreshBindings = "magitRefreshBindings",
 }
 
 export const BindingsId = {
     VSpaceCode: `${extensionId}.${ConfigKey.Bindings}`,
     Overrides: `${extensionId}.${ConfigKey.Overrides}`,
     RefBindings: `${extensionId}.${ConfigKey.RefBindings}`,
+    RefreshBindings: `${extensionId}.${ConfigKey.RefreshBindings}`,
 };
 
 export const defaultStatusBarTimeout = 5000;

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -69,6 +69,12 @@ export async function activate(context: ExtensionContext) {
     context.subscriptions.push(
         commands.registerCommand(CommandId.ShowMagitRefMenu, showMagitRefMenu)
     );
+    context.subscriptions.push(
+        commands.registerCommand(
+            CommandId.ShowMagitRefreshMenu,
+            showMagitRefreshMenu
+        )
+    );
 
     context.subscriptions.push(
         commands.registerCommand(
@@ -168,10 +174,12 @@ function setUpWhichKey() {
         overrides: BindingsId.Overrides,
         title: "VSpaceCode",
     };
-    const magitArg = { bindings: BindingsId.RefBindings };
+    const magitRefArg = { bindings: BindingsId.RefBindings };
+    const magitRefreshArg = { bindings: BindingsId.RefreshBindings };
     return Promise.all([
         commands.executeCommand(CommandId.RegisterWhichKey, arg),
-        commands.executeCommand(CommandId.RegisterWhichKey, magitArg),
+        commands.executeCommand(CommandId.RegisterWhichKey, magitRefArg),
+        commands.executeCommand(CommandId.RegisterWhichKey, magitRefreshArg),
     ]);
 }
 
@@ -186,6 +194,13 @@ function showMagitRefMenu() {
     return commands.executeCommand(
         CommandId.ShowWhichKey,
         BindingsId.RefBindings
+    );
+}
+
+function showMagitRefreshMenu() {
+    return commands.executeCommand(
+        CommandId.ShowWhichKey,
+        BindingsId.RefreshBindings
     );
 }
 


### PR DESCRIPTION
This is a follow up to #339 to use whichkey instead for `gg` and `gr`