### PR TITLE
Add basic major mode for Elixir

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,8 +15,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
--   ⌨ Added whichkey menu for `g` in magit buffer which supports `g g` to move cursor to the top.
 -   Add Elixir major mode
+-   ⌨ Added whichkey menu for `g` in magit buffer which supports `g g` to move cursor to the top.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 -   ⌨ Added whichkey menu for `g` in magit buffer which supports `g g` to move cursor to the top.
+-   Add Elixir major mode
 
 ### Changed
 

--- a/package.json
+++ b/package.json
@@ -3791,6 +3791,20 @@
                                                 "type": "bindings",
                                                 "bindings": [
                                                     {
+                                                        "key": "p",
+                                                        "name": "Transform function call to pipe operator",
+                                                        "icon": "lightbulb-autofix",
+                                                        "type": "command",
+                                                        "command": "extension.toPipe"
+                                                    },
+                                                    {
+                                                        "key": "P",
+                                                        "name": "Transform pipe operator to function call",
+                                                        "icon": "lightbulb-autofix",
+                                                        "type": "command",
+                                                        "command": "extension.fromPipe"
+                                                    },
+                                                    {
                                                         "key": ".",
                                                         "name": "Quick fix",
                                                         "icon": "lightbulb-autofix",

--- a/package.json
+++ b/package.json
@@ -3678,6 +3678,13 @@
                                         "type": "bindings",
                                         "bindings": [
                                             {
+                                                "key": "o",
+                                                "name": "Expand selected macro",
+                                                "icon": "symbol-function",
+                                                "type": "command",
+                                                "command": "extension.expandMacro"
+                                            },
+                                            {
                                                 "key": "=",
                                                 "name": "+Format",
                                                 "icon": "list-flat",
@@ -3733,13 +3740,6 @@
                                                 "icon": "go-to-file",
                                                 "type": "bindings",
                                                 "bindings": [
-                                                    {
-                                                        "key": "m",
-                                                        "name": "Expand selected macro",
-                                                        "icon": "symbol-function",
-                                                        "type": "command",
-                                                        "command": "extension.expandMacro"
-                                                    },
                                                     {
                                                         "key": "d",
                                                         "name": "Go to definition",

--- a/package.json
+++ b/package.json
@@ -3734,6 +3734,13 @@
                                                 "type": "bindings",
                                                 "bindings": [
                                                     {
+                                                        "key": "m",
+                                                        "name": "Expand selected macro",
+                                                        "icon": "symbol-function",
+                                                        "type": "command",
+                                                        "command": "extension.expandMacro"
+                                                    },
+                                                    {
                                                         "key": "d",
                                                         "name": "Go to definition",
                                                         "icon": "symbol-function",

--- a/package.json
+++ b/package.json
@@ -3673,6 +3673,171 @@
                                         ]
                                     },
                                     {
+                                        "key": "languageId:elixir",
+                                        "name": "Elixir",
+                                        "type": "bindings",
+                                        "bindings": [
+                                            {
+                                                "key": "=",
+                                                "name": "+Format",
+                                                "icon": "list-flat",
+                                                "type": "bindings",
+                                                "bindings": [
+                                                    {
+                                                        "key": "=",
+                                                        "name": "Format region or buffer",
+                                                        "icon": "list-flat",
+                                                        "type": "command",
+                                                        "command": "editor.action.format"
+                                                    },
+                                                    {
+                                                        "key": "b",
+                                                        "name": "Format buffer",
+                                                        "icon": "file",
+                                                        "type": "command",
+                                                        "command": "editor.action.formatDocument"
+                                                    },
+                                                    {
+                                                        "key": "c",
+                                                        "name": "Format changes",
+                                                        "icon": "diff",
+                                                        "type": "command",
+                                                        "command": "editor.action.formatChanges"
+                                                    },
+                                                    {
+                                                        "key": "s",
+                                                        "name": "Format selection",
+                                                        "icon": "selection",
+                                                        "type": "command",
+                                                        "command": "editor.action.formatSelection"
+                                                    },
+                                                    {
+                                                        "key": "B",
+                                                        "name": "+Format buffer with formatter",
+                                                        "icon": "file",
+                                                        "type": "command",
+                                                        "command": "editor.action.formatDocument.multiple"
+                                                    },
+                                                    {
+                                                        "key": "S",
+                                                        "name": "+Format selection with formatter",
+                                                        "icon": "selection",
+                                                        "type": "command",
+                                                        "command": "editor.action.formatSelection.multiple"
+                                                    }
+                                                ]
+                                            },
+                                            {
+                                                "key": "g",
+                                                "name": "+Go to",
+                                                "icon": "go-to-file",
+                                                "type": "bindings",
+                                                "bindings": [
+                                                    {
+                                                        "key": "d",
+                                                        "name": "Go to definition",
+                                                        "icon": "symbol-function",
+                                                        "type": "command",
+                                                        "command": "editor.action.revealDefinition"
+                                                    },
+                                                    {
+                                                        "key": "e",
+                                                        "name": "Go to errors/problems",
+                                                        "icon": "error",
+                                                        "type": "command",
+                                                        "command": "workbench.action.problems.focus"
+                                                    },
+                                                    {
+                                                        "key": "g",
+                                                        "name": "Go to definition",
+                                                        "icon": "symbol-function",
+                                                        "type": "command",
+                                                        "command": "editor.action.revealDefinition"
+                                                    },
+                                                    {
+                                                        "key": "i",
+                                                        "name": "Go to implementations",
+                                                        "icon": "symbol-module",
+                                                        "type": "command",
+                                                        "command": "editor.action.goToImplementation"
+                                                    },
+                                                    {
+                                                        "key": "r",
+                                                        "name": "Go to references",
+                                                        "icon": "symbol-reference",
+                                                        "type": "command",
+                                                        "command": "editor.action.goToReferences"
+                                                    },
+                                                    {
+                                                        "key": "I",
+                                                        "name": "Find implementations",
+                                                        "icon": "symbol-module",
+                                                        "type": "command",
+                                                        "command": "references-view.findImplementations"
+                                                    },
+                                                    {
+                                                        "key": "R",
+                                                        "name": "Find references",
+                                                        "icon": "symbol-reference",
+                                                        "type": "command",
+                                                        "command": "references-view.findReferences"
+                                                    }
+                                                ]
+                                            },
+                                            {
+                                                "key": "r",
+                                                "name": "+Refactor",
+                                                "icon": "edit",
+                                                "type": "bindings",
+                                                "bindings": [
+                                                    {
+                                                        "key": ".",
+                                                        "name": "Quick fix",
+                                                        "icon": "lightbulb-autofix",
+                                                        "type": "command",
+                                                        "command": "editor.action.quickFix"
+                                                    },
+                                                    {
+                                                        "key": "r",
+                                                        "name": "Rename symbol",
+                                                        "icon": "symbol-keyword",
+                                                        "type": "command",
+                                                        "command": "editor.action.rename"
+                                                    }
+                                                ]
+                                            },
+                                            {
+                                                "key": "G",
+                                                "name": "+Peek",
+                                                "icon": "eye",
+                                                "type": "bindings",
+                                                "bindings": [
+                                                    {
+                                                        "key": "d",
+                                                        "name": "Peek definition",
+                                                        "icon": "symbol-function",
+                                                        "type": "command",
+                                                        "command": "editor.action.peekDefinition"
+                                                    },
+                                                    {
+                                                        "key": "i",
+                                                        "name": "Peek implementations",
+                                                        "icon": "symbol-module",
+                                                        "type": "command",
+                                                        "command": "editor.action.peekImplementation"
+                                                    },
+                                                    {
+                                                        "key": "r",
+                                                        "name": "Peek references",
+                                                        "icon": "symbol-reference",
+                                                        "type": "command",
+                                                        "command": "editor.action.referenceSearch.trigger"
+                                                    }
+                                                ]
+                                            }
+                                        ]
+                                    },
+                                    {
                                         "key": "languageId:fsharp",
                                         "name": "F#",
                                         "type": "bindings",


### PR DESCRIPTION
<!-- Please explain the changes you made -->

<!--
Please, make sure:
- you have read the contributing guidelines:
  https://github.com/VSpaceCode/VSpaceCode/blob/master/CONTRIBUTING.md
- you have updated the changelog (if needed):
  https://github.com/VSpaceCode/VSpaceCode/blob/master/CHANGELOG.md
- `npm run sort-bindings` is run to ensure the bindings are sorted
  (if you are contributing updates to bindings)
-->
Adds a _very simple_ major mode for Elixir.

(see issue https://github.com/VSpaceCode/VSpaceCode/issues/292 and https://github.com/VSpaceCode/VSpaceCode/issues/98)

Goal is to simply add basic VS Code features as spacemacs style bindings.  In the future, it would be great to add more keybindings for specific elixir-lsp features, but I haven't gotten that far yet.

Let me know if there's anything I'm missing for a reasonable first-pass.