### PR TITLE
Python&Rust: Standardize refactor rename

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -27,7 +27,7 @@ This extension aims to provide the best out-of-the-box experience like spacemacs
     ```
 
 4. Install [TypeScript + Webpack Problem Matchers for VS Code](https://marketplace.visualstudio.com/items?itemName=eamodio.tsl-problem-matcher)
-5. Go to debug tab select `Run Extension`
+5. Go to debug tab select `Launch Extension`
 
 ## Submitting Issues
 

--- a/package.json
+++ b/package.json
@@ -6401,6 +6401,13 @@
                                                         "command": "editor.action.refactor"
                                                     },
                                                     {
+                                                        "key": "r",
+                                                        "name": "Rename symbol",
+                                                        "icon": "symbol-keyword",
+                                                        "type": "command",
+                                                        "command": "editor.action.rename"
+                                                    },
+                                                    {
                                                         "key": "I",
                                                         "name": "Sort imports",
                                                         "icon": "selection",
@@ -6859,6 +6866,28 @@
                                                         "icon": "project",
                                                         "type": "command",
                                                         "command": "workbench.action.showAllSymbols"
+                                                    }
+                                                ]
+                                            },
+                                            {
+                                                "key": "r",
+                                                "name": "+Refactor",
+                                                "icon": "edit",
+                                                "type": "bindings",
+                                                "bindings": [
+                                                    {
+                                                        "key": ".",
+                                                        "name": "Refactor menu",
+                                                        "icon": "lightbulb",
+                                                        "type": "command",
+                                                        "command": "editor.action.refactor"
+                                                    },
+                                                    {
+                                                        "key": "r",
+                                                        "name": "Rename symbol",
+                                                        "icon": "symbol-keyword",
+                                                        "type": "command",
+                                                        "command": "editor.action.rename"
                                                     }
                                                 ]
                                             },


### PR DESCRIPTION
<!-- Please explain the changes you made -->

closes #349 

- Add rename action for Python
- Add rename for Rust under the standard `SPC m r r` shortcut

<!--
Please, make sure:
- you have read the contributing guidelines:
  https://github.com/VSpaceCode/VSpaceCode/blob/master/CONTRIBUTING.md
- you have updated the changelog (if needed):
  https://github.com/VSpaceCode/VSpaceCode/blob/master/CHANGELOG.md
- `npm run sort-bindings` is run to ensure the bindings are sorted
  (if you are contributing updates to bindings)
-->
