### PR TITLE
Add editor layout bindings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added 
+
+-   Add window layout bindings
+    -   `SPC w 1` to open single column window layout
+    -   `SPC w 2` to open double column window layout
+    -   `SPC w 3` to open triple column window layout
+    -   `SPC w 4` to open grid window layout
+
 ## [0.10.17] - 2024-01-20
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -8654,6 +8654,34 @@
                                         ]
                                     },
                                     {
+                                        "key": "1",
+                                        "name": "Single column window layout",
+                                        "icon": "editor-layout",
+                                        "type": "command",
+                                        "command": "workbench.action.editorLayoutSingle"
+                                    },
+                                    {
+                                        "key": "2",
+                                        "name": "Double column window layout",
+                                        "icon": "editor-layout",
+                                        "type": "command",
+                                        "command": "workbench.action.editorLayoutTwoColumns"
+                                    },
+                                    {
+                                        "key": "3",
+                                        "name": "Triple column window layout",
+                                        "icon": "editor-layout",
+                                        "type": "command",
+                                        "command": "workbench.action.editorLayoutThreeColumns"
+                                    },
+                                    {
+                                        "key": "4",
+                                        "name": "Grid window layout",
+                                        "icon": "editor-layout",
+                                        "type": "command",
+                                        "command": "workbench.action.editorLayoutTwoByTwoGrid"
+                                    },
+                                    {
                                         "key": "d",
                                         "name": "Close window",
                                         "icon": "close",


### PR DESCRIPTION
Add editor (named window in the UI) layout bindings from Spacemacs. Resolves #356.

![Screenshot of VSCode which-key window menu](https://github.com/VSpaceCode/VSpaceCode/assets/23344719/ba57f06b-beac-49d9-8d68-e30bee531d59)

<!--
Please, make sure:
- you have read the contributing guidelines:
  https://github.com/VSpaceCode/VSpaceCode/blob/master/CONTRIBUTING.md
- you have updated the changelog (if needed):
  https://github.com/VSpaceCode/VSpaceCode/blob/master/CHANGELOG.md
- `npm run sort-bindings` is run to ensure the bindings are sorted
  (if you are contributing updates to bindings)
-->
