### PR TITLE
fix quarto render

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 -   Fixed outdated Flutter commands
+-   Fixed render in Quarto mode
 
 ## [0.10.17] - 2024-01-20
 

--- a/package.json
+++ b/package.json
@@ -6827,7 +6827,7 @@
                                                 "name": "Render",
                                                 "type": "command",
                                                 "icon": "check",
-                                                "command": "quarto.render"
+                                                "command": "quarto.renderDocument"
                                             },
                                             {
                                                 "key": "s",


### PR DESCRIPTION
Fix `quarto.render`, which changed to `quarto.renderDocument`