### PR TITLE
bindings for R create terminal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,10 +31,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     -   `SPC w 2` to open double column window layout
     -   `SPC w 3` to open triple column window layout
     -   `SPC w 4` to open grid window layout
+-   Add R create terminal in R and Quarto mode.
 
 ### Fixed
 
 -   Fixed outdated Flutter commands
+
+## Changed
+-   Changed Quarto Run current cell to `SPC m S`.
 
 ## [0.10.17] - 2024-01-20
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 -   Add C major mode key bindings
 -   Add R Package bindings in R Mode
--   Add R create terminal in R and Quarto mode.
+-   Add R create terminal in R and Quarto mode with `SPC m m` and `SPC m '`.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 -   Fixed outdated Flutter commands
 
 ## Changed
+
 -   Changed Quarto Run current cell to `SPC m S`.
 
 ## [0.10.17] - 2024-01-20

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 -   Add C major mode key bindings
 -   Add R Package bindings in R Mode
+-   Add R create terminal in R and Quarto mode.
 
 ### Fixed
 
@@ -31,7 +32,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     -   `SPC w 2` to open double column window layout
     -   `SPC w 3` to open triple column window layout
     -   `SPC w 4` to open grid window layout
--   Add R create terminal in R and Quarto mode.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 -   Fixed render in Quarto mode
 
+## Changed
+
+-   Changed Quarto Run current cell to `SPC m S`.
+
 ## [0.10.28] - 2024-02-28
 
 ### Added
@@ -36,10 +40,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 -   Fixed outdated Flutter commands
-
-## Changed
-
--   Changed Quarto Run current cell to `SPC m S`.
 
 ## [0.10.17] - 2024-01-20
 

--- a/package.json
+++ b/package.json
@@ -7009,13 +7009,6 @@
                                                 "command": "r.createRTerm"
                                             },
                                             {
-                                                "key": "S",
-                                                "name": "Run current cell",
-                                                "icon": "play",
-                                                "type": "command",
-                                                "command": "quarto.runCurrentCell"
-                                            },
-                                            {
                                                 "key": "o",
                                                 "name": "Objects in workspace R",
                                                 "type": "command",
@@ -7044,6 +7037,13 @@
                                                 "icon": "debug-restart",
                                                 "command": "r.runCommand",
                                                 "args": "rstudioapi::restartSession()"
+                                            },
+                                            {
+                                                "key": "S",
+                                                "name": "Run current cell",
+                                                "icon": "play",
+                                                "type": "command",
+                                                "command": "quarto.runCurrentCell"
                                             },
                                             {
                                                 "key": "=",
@@ -7381,6 +7381,13 @@
                                                 "command": "r.helpPanel.openForSelection"
                                             },
                                             {
+                                                "key": "m",
+                                                "name": "Create R Terminal",
+                                                "icon": "terminal",
+                                                "type": "command",
+                                                "command": "r.createRTerm"
+                                            },
+                                            {
                                                 "key": "o",
                                                 "name": "Objects in workspace R",
                                                 "type": "command",
@@ -7394,13 +7401,6 @@
                                                 "icon": "play",
                                                 "type": "command",
                                                 "command": "r.runSelection"
-                                            },
-                                            {
-                                                "key": "m",
-                                                "name": "Create R Terminal",
-                                                "icon": "terminal",
-                                                "type": "command",
-                                                "command": "r.createRTerm"
                                             },
                                             {
                                                 "key": "R",

--- a/package.json
+++ b/package.json
@@ -7003,6 +7003,13 @@
                                             },
                                             {
                                                 "key": "m",
+                                                "name": "Create R Terminal",
+                                                "icon": "terminal",
+                                                "type": "command",
+                                                "command": "r.createRTerm"
+                                            },
+                                            {
+                                                "key": "S",
                                                 "name": "Run current cell",
                                                 "icon": "play",
                                                 "type": "command",
@@ -7026,7 +7033,7 @@
                                             {
                                                 "key": "s",
                                                 "name": "Run selection",
-                                                "icon": "selection",
+                                                "icon": "play",
                                                 "type": "command",
                                                 "command": "quarto.runSelection"
                                             },
@@ -7387,6 +7394,13 @@
                                                 "icon": "play",
                                                 "type": "command",
                                                 "command": "r.runSelection"
+                                            },
+                                            {
+                                                "key": "m",
+                                                "name": "Create R Terminal",
+                                                "icon": "terminal",
+                                                "type": "command",
+                                                "command": "r.createRTerm"
                                             },
                                             {
                                                 "key": "R",

--- a/package.json
+++ b/package.json
@@ -6980,6 +6980,13 @@
                                         "type": "bindings",
                                         "bindings": [
                                             {
+                                                "key": "'",
+                                                "name": "Create R Terminal",
+                                                "icon": "terminal",
+                                                "type": "command",
+                                                "command": "r.createRTerm"
+                                            },
+                                            {
                                                 "key": "d",
                                                 "name": "Debugonce R",
                                                 "type": "command",
@@ -7365,6 +7372,13 @@
                                         "name": "R",
                                         "type": "bindings",
                                         "bindings": [
+                                            {
+                                                "key": "'",
+                                                "name": "Create R Terminal",
+                                                "icon": "terminal",
+                                                "type": "command",
+                                                "command": "r.createRTerm"
+                                            },
                                             {
                                                 "key": "d",
                                                 "name": "Debugonce",


### PR DESCRIPTION
Added bindings for `R create terminal` in `R` and Quarto` mode. This is relevant because `Run Selection` does not automatically start an R Terminal when `r.alwaysUseActiveTerminal` is set to true. However, this is a recommended setting for multi-session https://renkun.me/2020/04/14/writing-r-in-vscode-working-with-multiple-r-sessions/ or sending code to a shell from a docker container (when not working in a devcontainer).