### PR TITLE
Fix typo: keybindngs

### DIFF
--- a/src/messages.ts
+++ b/src/messages.ts
@@ -4,9 +4,9 @@ import { ComparisonResult, Version } from "./version";
 export const configSettingsConfirmTitle =
     "Configuring settings may change the format of your settings.json file. Are you sure?";
 export const configKeybindingsConfirmTitle =
-    "Configuring keybindings may change the format of your keybindngs.json file. Are you sure?";
+    "Configuring keybindings may change the format of your keybindings.json file. Are you sure?";
 export const configConfirmTitle =
-    "Configuration may change the format of your settings.json and keybindngs.json file. Are you sure?";
+    "Configuration may change the format of your settings.json and keybindings.json file. Are you sure?";
 
 export function confirmWrapper(title: string, fn: () => Thenable<any>) {
     return async () => {


### PR DESCRIPTION
The typo appears in the confirmation popup after clicking "Configure for you" on the page:
Get Started with VSpaceCode

<img width="596" height="720" alt="Code_xFd4vsg1nS" src="https://github.com/user-attachments/assets/4a4b34fb-c085-49e0-b9de-3fe9d117db8a" />
