### PR TITLE
Fix TAB key in edamagit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+-   ⌨️ Fixed broken `TAB` in edamagit
+
 ## [0.10.20] - 2025-07-12
 
 ### Fixed

--- a/src/configuration/keybindings.jsonc
+++ b/src/configuration/keybindings.jsonc
@@ -17,12 +17,12 @@
     {
         "key": "tab",
         "command": "extension.vim_tab",
-        "when": "editorTextFocus && vim.active && !inDebugRepl && vim.mode != 'Insert' && editorLangId != 'magit'"
+        "when": "editorTextFocus && vim.active && !inDebugRepl && vim.mode != 'Insert' && !inlineEditIsVisible && editorLangId != 'magit'"
     },
     {
         "key": "tab",
         "command": "-extension.vim_tab",
-        "when": "editorTextFocus && vim.active && !inDebugRepl && vim.mode != 'Insert'"
+        "when": "editorTextFocus && vim.active && !inDebugRepl && vim.mode != 'Insert' && !inlineEditIsVisible"
     },
     {
         "key": "x",

--- a/src/configuration/legacyKeybindings.jsonc
+++ b/src/configuration/legacyKeybindings.jsonc
@@ -3,5 +3,15 @@
         "key": "space",
         "command": "vspacecode.space",
         "when": "activeEditorGroupEmpty && focusedView == '' && !whichkeyActive"
+    },
+    {
+        "key": "tab",
+        "command": "extension.vim_tab",
+        "when": "editorTextFocus && vim.active && !inDebugRepl && vim.mode != 'Insert' && editorLangId != 'magit'"
+    },
+    {
+        "key": "tab",
+        "command": "-extension.vim_tab",
+        "when": "editorTextFocus && vim.active && !inDebugRepl && vim.mode != 'Insert'"
     }
 ]


### PR DESCRIPTION
fixes #391

This commit addresses the broken TAB key functionality within edamagit, which was caused by a change in VSCodeVim's default keybindings to support Next Edit Suggestions. VSCodeVim/Vim@bba5de0

Similar documentation update was made on edamagit as well kahole/edamagit@c7a5221.

User will need to perform vscode keybindings reconfiguration to fix this.
