### PR TITLE
Change 'Go to definition' to 'Go to declaration' for Python

### DIFF
--- a/package.json
+++ b/package.json
@@ -6816,10 +6816,10 @@
                                                     },
                                                     {
                                                         "key": "g",
-                                                        "name": "Go to definition",
+                                                        "name": "Go to declaration",
                                                         "icon": "symbol-function",
                                                         "type": "command",
-                                                        "command": "editor.action.revealDefinition"
+                                                        "command": "editor.action.revealDeclaration"
                                                     },
                                                     {
                                                         "key": "r",


### PR DESCRIPTION
Go to definition is duplicated for `,gg`and `,gd`in Python major mode.
I replaced the title and command accordingly with `delcaration` instead of `definition`.