### PR TITLE
Change `m g d` to 'Go to declaration' for Python major mode

### DIFF
--- a/package.json
+++ b/package.json
@@ -6802,10 +6802,10 @@
                                                 "bindings": [
                                                     {
                                                         "key": "d",
-                                                        "name": "Go to definition",
+                                                        "name": "Go to declaration",
                                                         "icon": "symbol-function",
                                                         "type": "command",
-                                                        "command": "editor.action.revealDefinition"
+                                                        "command": "editor.action.revealDeclaration"
                                                     },
                                                     {
                                                         "key": "e",


### PR DESCRIPTION
`m g d` is a duplication of `m g g` in Python major mode, so I fixed that.

KR
